### PR TITLE
docs: add crate readmes for crates.io

### DIFF
--- a/a2a-client/Cargo.toml
+++ b/a2a-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-a2a-client"
 version = "0.1.3"
 description = "A2A v1 async client with protocol binding factory"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/a2a-client/README.md
+++ b/a2a-client/README.md
@@ -1,0 +1,27 @@
+# agntcy-a2a-client
+
+Async Rust client for A2A v1 agents.
+
+This crate is published as `agntcy-a2a-client` and imported in Rust as `a2a_client`.
+
+## What It Provides
+
+- REST and JSON-RPC transports
+- Agent card resolution and transport selection helpers
+- A high-level `A2AClient` wrapper
+- Streaming response parsing for SSE-based endpoints
+
+## Install
+
+```toml
+[dependencies]
+a2a = { package = "agntcy-a2a", version = "0.2" }
+a2a-client = { package = "agntcy-a2a-client", version = "0.1" }
+```
+
+## Workspace
+
+This crate is part of the `a2a-rs` workspace.
+
+- Repository: https://github.com/agntcy/a2a-rs
+- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md

--- a/a2a-grpc/Cargo.toml
+++ b/a2a-grpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-a2a-grpc"
 version = "0.1.0"
 description = "A2A v1 gRPC protocol binding for client and server"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/a2a-grpc/README.md
+++ b/a2a-grpc/README.md
@@ -1,0 +1,26 @@
+# agntcy-a2a-grpc
+
+gRPC bindings for A2A v1 client and server implementations.
+
+This crate is published as `agntcy-a2a-grpc` and imported in Rust as `a2a_grpc`.
+
+## What It Provides
+
+- Tonic-based client transport bindings
+- Tonic service adapters for A2A request handlers
+- Conversion glue between native models and protobuf messages
+
+## Install
+
+```toml
+[dependencies]
+a2a = { package = "agntcy-a2a", version = "0.2" }
+a2a-grpc = { package = "agntcy-a2a-grpc", version = "0.1" }
+```
+
+## Workspace
+
+This crate is part of the `a2a-rs` workspace.
+
+- Repository: https://github.com/agntcy/a2a-rs
+- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md

--- a/a2a-pb/Cargo.toml
+++ b/a2a-pb/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-a2a-pb"
 version = "0.1.0"
 description = "A2A v1 protobuf-generated types and conversion layer"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/a2a-pb/README.md
+++ b/a2a-pb/README.md
@@ -1,0 +1,26 @@
+# agntcy-a2a-pb
+
+Protobuf schema and conversion helpers for A2A v1.
+
+This crate is published as `agntcy-a2a-pb` and imported in Rust as `a2a_pb`.
+
+## What It Provides
+
+- Generated protobuf types for the A2A schema
+- Conversion helpers between protobuf and native Rust models
+- The bundled A2A proto definition used by the Rust workspace
+
+## Install
+
+```toml
+[dependencies]
+a2a = { package = "agntcy-a2a", version = "0.2" }
+a2a-pb = { package = "agntcy-a2a-pb", version = "0.1" }
+```
+
+## Workspace
+
+This crate is part of the `a2a-rs` workspace.
+
+- Repository: https://github.com/agntcy/a2a-rs
+- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md

--- a/a2a-server/Cargo.toml
+++ b/a2a-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-a2a-server"
 version = "0.1.0"
 description = "A2A v1 async server framework"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/a2a-server/README.md
+++ b/a2a-server/README.md
@@ -1,0 +1,27 @@
+# agntcy-a2a-server
+
+Async server framework for implementing A2A v1 agents in Rust.
+
+This crate is published as `agntcy-a2a-server` and imported in Rust as `a2a_server`.
+
+## What It Provides
+
+- REST and JSON-RPC routers built on `axum`
+- A transport-agnostic `RequestHandler` abstraction
+- A default handler and in-memory task store
+- SSE helpers for streaming task responses
+
+## Install
+
+```toml
+[dependencies]
+a2a = { package = "agntcy-a2a", version = "0.2" }
+a2a-server = { package = "agntcy-a2a-server", version = "0.1" }
+```
+
+## Workspace
+
+This crate is part of the `a2a-rs` workspace.
+
+- Repository: https://github.com/agntcy/a2a-rs
+- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md

--- a/a2a/Cargo.toml
+++ b/a2a/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agntcy-a2a"
 version = "0.2.0"
 description = "A2A v1 protocol types and core definitions"
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -1,0 +1,35 @@
+# agntcy-a2a
+
+Core Rust types for the A2A v1 protocol.
+
+This crate is published as `agntcy-a2a` and imported in Rust as `a2a`.
+
+## What It Provides
+
+- A2A wire-compatible message, task, artifact, and event types
+- JSON-RPC request and response models
+- Protocol error types and helpers
+- Serde implementations aligned with the A2A protocol shape
+
+## Install
+
+```toml
+[dependencies]
+a2a = { package = "agntcy-a2a", version = "0.2" }
+```
+
+## Example
+
+```rust
+use a2a::{Message, Part, Role};
+
+let message = Message::new(Role::User, vec![Part::text("hello")]);
+assert_eq!(message.text(), Some("hello"));
+```
+
+## Workspace
+
+This crate is part of the `a2a-rs` workspace.
+
+- Repository: https://github.com/agntcy/a2a-rs
+- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md


### PR DESCRIPTION
Add crate-local README files and manifest readme entries for all published crates so crates.io can render package documentation from the published tarballs.