### PR TITLE
docs: add crate rustdoc for agntcy-a2a

### DIFF
--- a/a2a/src/lib.rs
+++ b/a2a/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
+#![doc = include_str!("../README.md")]
+
 pub mod agent_card;
 pub mod errors;
 pub mod event;


### PR DESCRIPTION
## Summary
- publish the agntcy-a2a crate README as the root rustdoc page
- make the README example run as a doctest
- prepare the next release so docs.rs has a real landing page for the core crate
