### PR TITLE
fix: align HTTP+JSON REST interop

### DIFF
--- a/a2a-client/src/rest.rs
+++ b/a2a-client/src/rest.rs
@@ -4,8 +4,41 @@ use a2a::*;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::HashMap;
 
 use crate::transport::{ServiceParams, Transport, TransportFactory};
+
+const REST_SEND_MESSAGE_PATH: &str = "/message:send";
+const REST_STREAM_MESSAGE_PATH: &str = "/message:stream";
+const REST_EXTENDED_AGENT_CARD_PATH: &str = "/extendedAgentCard";
+const REST_ERROR_INFO_TYPE_URL: &str = "type.googleapis.com/google.rpc.ErrorInfo";
+const REST_ERROR_DOMAIN: &str = "a2a-protocol.org";
+
+#[derive(Debug, Deserialize)]
+struct RestErrorEnvelope {
+    error: RestErrorStatus,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestErrorStatus {
+    message: String,
+
+    #[serde(default)]
+    details: Vec<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RestErrorInfo {
+    #[serde(rename = "@type")]
+    type_url: String,
+    reason: String,
+    domain: String,
+
+    #[serde(default)]
+    metadata: HashMap<String, String>,
+}
 
 /// REST (HTTP+JSON) transport implementation.
 ///
@@ -37,6 +70,34 @@ impl RestTransport {
         builder
     }
 
+    fn build_request_with_query(
+        &self,
+        method: reqwest::Method,
+        path: &str,
+        params: &ServiceParams,
+        query: &[(String, String)],
+    ) -> reqwest::RequestBuilder {
+        let builder = self.build_request(method, path, params);
+        if query.is_empty() {
+            builder
+        } else {
+            builder.query(query)
+        }
+    }
+
+    async fn send(&self, builder: reqwest::RequestBuilder) -> Result<reqwest::Response, A2AError> {
+        builder
+            .send()
+            .await
+            .map_err(|e| A2AError::internal(format!("HTTP request failed: {e}")))
+    }
+
+    async fn into_rest_error(resp: reqwest::Response) -> A2AError {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        parse_rest_error(status, &body)
+    }
+
     async fn post_json<T: serde::de::DeserializeOwned>(
         &self,
         path: &str,
@@ -44,16 +105,14 @@ impl RestTransport {
         body: &impl serde::Serialize,
     ) -> Result<T, A2AError> {
         let resp = self
-            .build_request(reqwest::Method::POST, path, params)
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| A2AError::internal(format!("HTTP request failed: {e}")))?;
+            .send(
+                self.build_request(reqwest::Method::POST, path, params)
+                    .json(body),
+            )
+            .await?;
 
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(A2AError::internal(format!("HTTP {status}: {body}")));
+        if !resp.status().is_success() {
+            return Err(Self::into_rest_error(resp).await);
         }
 
         resp.json()
@@ -65,17 +124,14 @@ impl RestTransport {
         &self,
         path: &str,
         params: &ServiceParams,
+        query: &[(String, String)],
     ) -> Result<T, A2AError> {
         let resp = self
-            .build_request(reqwest::Method::GET, path, params)
-            .send()
-            .await
-            .map_err(|e| A2AError::internal(format!("HTTP request failed: {e}")))?;
+            .send(self.build_request_with_query(reqwest::Method::GET, path, params, query))
+            .await?;
 
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(A2AError::internal(format!("HTTP {status}: {body}")));
+        if !resp.status().is_success() {
+            return Err(Self::into_rest_error(resp).await);
         }
 
         resp.json()
@@ -90,12 +146,36 @@ impl RestTransport {
         body: &impl serde::Serialize,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
         let resp = self
-            .build_request(reqwest::Method::POST, path, params)
-            .header("Accept", "text/event-stream")
-            .json(body)
-            .send()
-            .await
-            .map_err(|e| A2AError::internal(format!("HTTP request failed: {e}")))?;
+            .send(
+                self.build_request(reqwest::Method::POST, path, params)
+                    .header("Accept", "text/event-stream")
+                    .json(body),
+            )
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(Self::into_rest_error(resp).await);
+        }
+
+        let stream = resp.bytes_stream();
+        Ok(crate::jsonrpc::parse_sse_stream_rest(stream))
+    }
+
+    async fn get_streaming(
+        &self,
+        path: &str,
+        params: &ServiceParams,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        let resp = self
+            .send(
+                self.build_request(reqwest::Method::GET, path, params)
+                    .header("Accept", "text/event-stream"),
+            )
+            .await?;
+
+        if !resp.status().is_success() {
+            return Err(Self::into_rest_error(resp).await);
+        }
 
         let stream = resp.bytes_stream();
         Ok(crate::jsonrpc::parse_sse_stream_rest(stream))
@@ -103,17 +183,68 @@ impl RestTransport {
 
     async fn delete(&self, path: &str, params: &ServiceParams) -> Result<(), A2AError> {
         let resp = self
-            .build_request(reqwest::Method::DELETE, path, params)
-            .send()
-            .await
-            .map_err(|e| A2AError::internal(format!("HTTP request failed: {e}")))?;
+            .send(self.build_request(reqwest::Method::DELETE, path, params))
+            .await?;
 
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(A2AError::internal(format!("HTTP {status}: {body}")));
+        if !resp.status().is_success() {
+            return Err(Self::into_rest_error(resp).await);
         }
         Ok(())
+    }
+}
+
+fn parse_rest_error(status: reqwest::StatusCode, body: &str) -> A2AError {
+    let Ok(envelope) = serde_json::from_str::<RestErrorEnvelope>(body) else {
+        return A2AError::internal(format!("HTTP {status}: {body}"));
+    };
+
+    let mut details = HashMap::new();
+    let mut code = None;
+
+    for raw_detail in envelope.error.details {
+        if let Ok(info) = serde_json::from_value::<RestErrorInfo>(raw_detail.clone()) {
+            if info.type_url == REST_ERROR_INFO_TYPE_URL && info.domain == REST_ERROR_DOMAIN {
+                code = reason_to_error_code(&info.reason).or(code);
+                for (key, value) in info.metadata {
+                    details.insert(key, Value::String(value));
+                }
+                continue;
+            }
+        }
+
+        if let Value::Object(values) = raw_detail {
+            details.extend(values.into_iter());
+        }
+    }
+
+    A2AError {
+        code: code.unwrap_or(error_code::INTERNAL_ERROR),
+        message: envelope.error.message,
+        details: (!details.is_empty()).then_some(details),
+    }
+}
+
+fn reason_to_error_code(reason: &str) -> Option<i32> {
+    match reason {
+        "TASK_NOT_FOUND" => Some(error_code::TASK_NOT_FOUND),
+        "TASK_NOT_CANCELABLE" => Some(error_code::TASK_NOT_CANCELABLE),
+        "PUSH_NOTIFICATION_NOT_SUPPORTED" => Some(error_code::PUSH_NOTIFICATION_NOT_SUPPORTED),
+        "UNSUPPORTED_OPERATION" => Some(error_code::UNSUPPORTED_OPERATION),
+        "UNSUPPORTED_CONTENT_TYPE" | "CONTENT_TYPE_NOT_SUPPORTED" => {
+            Some(error_code::CONTENT_TYPE_NOT_SUPPORTED)
+        }
+        "INVALID_AGENT_RESPONSE" => Some(error_code::INVALID_AGENT_RESPONSE),
+        "EXTENDED_AGENT_CARD_NOT_CONFIGURED" | "EXTENDED_CARD_NOT_CONFIGURED" => {
+            Some(error_code::EXTENDED_CARD_NOT_CONFIGURED)
+        }
+        "EXTENSION_SUPPORT_REQUIRED" => Some(error_code::EXTENSION_SUPPORT_REQUIRED),
+        "VERSION_NOT_SUPPORTED" => Some(error_code::VERSION_NOT_SUPPORTED),
+        "PARSE_ERROR" => Some(error_code::PARSE_ERROR),
+        "INVALID_REQUEST" => Some(error_code::INVALID_REQUEST),
+        "METHOD_NOT_FOUND" => Some(error_code::METHOD_NOT_FOUND),
+        "INVALID_PARAMS" => Some(error_code::INVALID_PARAMS),
+        "INTERNAL_ERROR" => Some(error_code::INTERNAL_ERROR),
+        _ => None,
     }
 }
 
@@ -124,7 +255,7 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
-        self.post_json("/message/send", params, req).await
+        self.post_json(REST_SEND_MESSAGE_PATH, params, req).await
     }
 
     async fn send_streaming_message(
@@ -132,7 +263,8 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
-        self.post_streaming("/message/stream", params, req).await
+        self.post_streaming(REST_STREAM_MESSAGE_PATH, params, req)
+            .await
     }
 
     async fn get_task(
@@ -140,16 +272,12 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &GetTaskRequest,
     ) -> Result<Task, A2AError> {
-        let mut path = format!("/tasks/{}", req.id);
+        let path = format!("/tasks/{}", req.id);
         let mut query_parts = Vec::new();
         if let Some(hl) = req.history_length {
-            query_parts.push(format!("historyLength={hl}"));
+            query_parts.push(("historyLength".to_string(), hl.to_string()));
         }
-        if !query_parts.is_empty() {
-            path.push('?');
-            path.push_str(&query_parts.join("&"));
-        }
-        self.get_json(&path, params).await
+        self.get_json(&path, params, &query_parts).await
     }
 
     async fn list_tasks(
@@ -159,33 +287,31 @@ impl Transport for RestTransport {
     ) -> Result<ListTasksResponse, A2AError> {
         let mut query_parts = Vec::new();
         if let Some(ref cid) = req.context_id {
-            query_parts.push(format!("contextId={cid}"));
+            query_parts.push(("contextId".to_string(), cid.clone()));
         }
         if let Some(ref status) = req.status {
             let s = serde_json::to_value(status)
                 .ok()
                 .and_then(|v| v.as_str().map(String::from))
                 .unwrap_or_default();
-            query_parts.push(format!("status={s}"));
+            query_parts.push(("status".to_string(), s));
         }
         if let Some(ps) = req.page_size {
-            query_parts.push(format!("pageSize={ps}"));
+            query_parts.push(("pageSize".to_string(), ps.to_string()));
         }
         if let Some(ref pt) = req.page_token {
-            query_parts.push(format!("pageToken={pt}"));
+            query_parts.push(("pageToken".to_string(), pt.clone()));
         }
         if let Some(hl) = req.history_length {
-            query_parts.push(format!("historyLength={hl}"));
+            query_parts.push(("historyLength".to_string(), hl.to_string()));
+        }
+        if let Some(ref ts) = req.status_timestamp_after {
+            query_parts.push(("statusTimestampAfter".to_string(), ts.to_rfc3339()));
         }
         if let Some(ia) = req.include_artifacts {
-            query_parts.push(format!("includeArtifacts={ia}"));
+            query_parts.push(("includeArtifacts".to_string(), ia.to_string()));
         }
-        let mut path = "/tasks".to_string();
-        if !query_parts.is_empty() {
-            path.push('?');
-            path.push_str(&query_parts.join("&"));
-        }
-        self.get_json(&path, params).await
+        self.get_json("/tasks", params, &query_parts).await
     }
 
     async fn cancel_task(
@@ -193,7 +319,7 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &CancelTaskRequest,
     ) -> Result<Task, A2AError> {
-        self.post_json(&format!("/tasks/{}/cancel", req.id), params, req)
+        self.post_json(&format!("/tasks/{}:cancel", req.id), params, req)
             .await
     }
 
@@ -202,7 +328,7 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &SubscribeToTaskRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
-        self.post_streaming(&format!("/tasks/{}/subscribe", req.id), params, req)
+        self.get_streaming(&format!("/tasks/{}:subscribe", req.id), params)
             .await
     }
 
@@ -212,7 +338,7 @@ impl Transport for RestTransport {
         req: &CreateTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         self.post_json(
-            &format!("/tasks/{}/push-configs", req.task_id),
+            &format!("/tasks/{}/pushNotificationConfigs", req.task_id),
             params,
             &req.config,
         )
@@ -225,8 +351,9 @@ impl Transport for RestTransport {
         req: &GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
         self.get_json(
-            &format!("/tasks/{}/push-configs/{}", req.task_id, req.id),
+            &format!("/tasks/{}/pushNotificationConfigs/{}", req.task_id, req.id),
             params,
+            &[],
         )
         .await
     }
@@ -236,8 +363,20 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
-        self.get_json(&format!("/tasks/{}/push-configs", req.task_id), params)
-            .await
+        let mut query_parts = Vec::new();
+        if let Some(page_size) = req.page_size {
+            query_parts.push(("pageSize".to_string(), page_size.to_string()));
+        }
+        if let Some(ref page_token) = req.page_token {
+            query_parts.push(("pageToken".to_string(), page_token.clone()));
+        }
+
+        self.get_json(
+            &format!("/tasks/{}/pushNotificationConfigs", req.task_id),
+            params,
+            &query_parts,
+        )
+        .await
     }
 
     async fn delete_push_config(
@@ -246,7 +385,7 @@ impl Transport for RestTransport {
         req: &DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
         self.delete(
-            &format!("/tasks/{}/push-configs/{}", req.task_id, req.id),
+            &format!("/tasks/{}/pushNotificationConfigs/{}", req.task_id, req.id),
             params,
         )
         .await
@@ -257,7 +396,8 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         _req: &GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
-        self.get_json("/agent-card/extended", params).await
+        self.get_json(REST_EXTENDED_AGENT_CARD_PATH, params, &[])
+            .await
     }
 
     async fn destroy(&self) -> Result<(), A2AError> {
@@ -299,6 +439,7 @@ impl TransportFactory for RestTransportFactory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn test_rest_transport_new_strips_trailing_slash() {
@@ -356,5 +497,61 @@ mod tests {
             .map(|v| v.to_str().unwrap().to_string())
             .collect();
         assert_eq!(vals, vec!["val1", "val2"]);
+    }
+
+    #[test]
+    fn test_parse_rest_error_preserves_a2a_error_code() {
+        let body = json!({
+            "error": {
+                "code": 404,
+                "status": "NOT_FOUND",
+                "message": "task not found: t1",
+                "details": [
+                    {
+                        "@type": REST_ERROR_INFO_TYPE_URL,
+                        "reason": "TASK_NOT_FOUND",
+                        "domain": REST_ERROR_DOMAIN,
+                        "metadata": {
+                            "taskId": "t1"
+                        }
+                    },
+                    {
+                        "resource": "task"
+                    }
+                ]
+            }
+        })
+        .to_string();
+
+        let err = parse_rest_error(reqwest::StatusCode::NOT_FOUND, &body);
+
+        assert_eq!(err.code, error_code::TASK_NOT_FOUND);
+        assert_eq!(err.message, "task not found: t1");
+        let details = err.details.expect("expected structured details");
+        assert_eq!(details.get("taskId"), Some(&Value::String("t1".into())));
+        assert_eq!(details.get("resource"), Some(&Value::String("task".into())));
+    }
+
+    #[test]
+    fn test_parse_rest_error_accepts_go_reason_aliases() {
+        let body = json!({
+            "error": {
+                "code": 400,
+                "status": "INVALID_ARGUMENT",
+                "message": "incompatible content types",
+                "details": [
+                    {
+                        "@type": REST_ERROR_INFO_TYPE_URL,
+                        "reason": "UNSUPPORTED_CONTENT_TYPE",
+                        "domain": REST_ERROR_DOMAIN,
+                        "metadata": {}
+                    }
+                ]
+            }
+        })
+        .to_string();
+
+        let err = parse_rest_error(reqwest::StatusCode::BAD_REQUEST, &body);
+        assert_eq!(err.code, error_code::CONTENT_TYPE_NOT_SUPPORTED);
     }
 }

--- a/a2a-server/src/rest.rs
+++ b/a2a-server/src/rest.rs
@@ -9,11 +9,49 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use serde::Deserialize;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 
 use crate::handler::RequestHandler;
 use crate::middleware::ServiceParams;
 use crate::sse;
+
+const REST_SEND_MESSAGE_PATH: &str = "/message:send";
+const REST_SEND_MESSAGE_LEGACY_PATH: &str = "/message/send";
+const REST_STREAM_MESSAGE_PATH: &str = "/message:stream";
+const REST_STREAM_MESSAGE_LEGACY_PATH: &str = "/message/stream";
+const REST_EXTENDED_AGENT_CARD_PATH: &str = "/extendedAgentCard";
+const REST_EXTENDED_AGENT_CARD_LEGACY_PATH: &str = "/agent-card/extended";
+const REST_PUSH_CONFIGS_PATH: &str = "/tasks/{id}/pushNotificationConfigs";
+const REST_PUSH_CONFIGS_LEGACY_PATH: &str = "/tasks/{id}/push-configs";
+const REST_PUSH_CONFIG_PATH: &str = "/tasks/{id}/pushNotificationConfigs/{config_id}";
+const REST_PUSH_CONFIG_LEGACY_PATH: &str = "/tasks/{id}/push-configs/{config_id}";
+const REST_ERROR_INFO_TYPE_URL: &str = "type.googleapis.com/google.rpc.ErrorInfo";
+const REST_ERROR_DOMAIN: &str = "a2a-protocol.org";
+
+#[derive(Serialize)]
+struct RestErrorEnvelope {
+    error: RestErrorStatus,
+}
+
+#[derive(Serialize)]
+struct RestErrorStatus {
+    code: u16,
+    status: &'static str,
+    message: String,
+    details: Vec<Value>,
+}
+
+#[derive(Serialize)]
+struct RestErrorInfo {
+    #[serde(rename = "@type")]
+    type_url: &'static str,
+    reason: &'static str,
+    domain: &'static str,
+    metadata: HashMap<String, String>,
+}
 
 /// Shared state for REST handlers.
 pub struct RestState<H: RequestHandler> {
@@ -33,33 +71,58 @@ pub fn rest_router<H: RequestHandler>(handler: Arc<H>) -> axum::Router {
     let state = RestState { handler };
     axum::Router::new()
         .route(
-            "/message/send",
+            REST_SEND_MESSAGE_PATH,
             axum::routing::post(handle_send_message::<H>),
         )
         .route(
-            "/message/stream",
+            REST_SEND_MESSAGE_LEGACY_PATH,
+            axum::routing::post(handle_send_message::<H>),
+        )
+        .route(
+            REST_STREAM_MESSAGE_PATH,
             axum::routing::post(handle_stream_message::<H>),
         )
-        .route("/tasks/{id}", axum::routing::get(handle_get_task::<H>))
+        .route(
+            REST_STREAM_MESSAGE_LEGACY_PATH,
+            axum::routing::post(handle_stream_message::<H>),
+        )
+        .route(
+            "/tasks/{id}",
+            axum::routing::get(handle_get_task_or_subscribe::<H>)
+                .post(handle_post_task_action::<H>),
+        )
         .route("/tasks", axum::routing::get(handle_list_tasks::<H>))
         .route(
             "/tasks/{id}/cancel",
-            axum::routing::post(handle_cancel_task::<H>),
+            axum::routing::post(handle_cancel_task_legacy::<H>),
         )
         .route(
             "/tasks/{id}/subscribe",
-            axum::routing::post(handle_subscribe_to_task::<H>),
+            axum::routing::get(handle_subscribe_to_task_legacy::<H>)
+                .post(handle_subscribe_to_task_legacy::<H>),
         )
         .route(
-            "/tasks/{id}/push-configs",
+            REST_PUSH_CONFIGS_PATH,
             axum::routing::post(handle_create_push_config::<H>).get(handle_list_push_configs::<H>),
         )
         .route(
-            "/tasks/{id}/push-configs/{config_id}",
+            REST_PUSH_CONFIGS_LEGACY_PATH,
+            axum::routing::post(handle_create_push_config::<H>).get(handle_list_push_configs::<H>),
+        )
+        .route(
+            REST_PUSH_CONFIG_PATH,
             axum::routing::get(handle_get_push_config::<H>).delete(handle_delete_push_config::<H>),
         )
         .route(
-            "/agent-card/extended",
+            REST_PUSH_CONFIG_LEGACY_PATH,
+            axum::routing::get(handle_get_push_config::<H>).delete(handle_delete_push_config::<H>),
+        )
+        .route(
+            REST_EXTENDED_AGENT_CARD_PATH,
+            axum::routing::get(handle_get_extended_agent_card::<H>),
+        )
+        .route(
+            REST_EXTENDED_AGENT_CARD_LEGACY_PATH,
             axum::routing::get(handle_get_extended_agent_card::<H>),
         )
         .with_state(state)
@@ -93,11 +156,11 @@ pub struct GetTaskQuery {
     pub history_length: Option<i32>,
 }
 
-async fn handle_get_task<H: RequestHandler>(
-    State(state): State<RestState<H>>,
-    Path(id): Path<String>,
-    Query(query): Query<GetTaskQuery>,
-) -> impl IntoResponse {
+async fn handle_get_task_inner<H: RequestHandler>(
+    state: RestState<H>,
+    id: String,
+    query: GetTaskQuery,
+) -> axum::response::Response {
     let params = ServiceParams::new();
     let req = GetTaskRequest {
         id,
@@ -108,6 +171,18 @@ async fn handle_get_task<H: RequestHandler>(
         Ok(task) => Json(task).into_response(),
         Err(e) => rest_error_response(e),
     }
+}
+
+async fn handle_get_task_or_subscribe<H: RequestHandler>(
+    State(state): State<RestState<H>>,
+    Path(id): Path<String>,
+    Query(query): Query<GetTaskQuery>,
+) -> impl IntoResponse {
+    if let Some(task_id) = id.strip_suffix(":subscribe") {
+        return handle_subscribe_to_task_inner(state, task_id.to_string()).await;
+    }
+
+    handle_get_task_inner(state, id, query).await
 }
 
 #[derive(Deserialize)]
@@ -122,6 +197,12 @@ pub struct ListTasksQuery {
     pub page_token: Option<String>,
     #[serde(default, rename = "historyLength")]
     pub history_length: Option<i32>,
+
+    #[serde(default, rename = "statusTimestampAfter")]
+    pub status_timestamp_after: Option<DateTime<Utc>>,
+
+    #[serde(default, rename = "includeArtifacts")]
+    pub include_artifacts: Option<bool>,
 }
 
 async fn handle_list_tasks<H: RequestHandler>(
@@ -138,8 +219,8 @@ async fn handle_list_tasks<H: RequestHandler>(
         page_size: query.page_size,
         page_token: query.page_token,
         history_length: query.history_length,
-        status_timestamp_after: None,
-        include_artifacts: None,
+        status_timestamp_after: query.status_timestamp_after,
+        include_artifacts: query.include_artifacts,
         tenant: None,
     };
     match state.handler.list_tasks(&params, req).await {
@@ -148,10 +229,10 @@ async fn handle_list_tasks<H: RequestHandler>(
     }
 }
 
-async fn handle_cancel_task<H: RequestHandler>(
-    State(state): State<RestState<H>>,
-    Path(id): Path<String>,
-) -> impl IntoResponse {
+async fn handle_cancel_task_inner<H: RequestHandler>(
+    state: RestState<H>,
+    id: String,
+) -> axum::response::Response {
     let params = ServiceParams::new();
     let req = CancelTaskRequest {
         id,
@@ -164,16 +245,53 @@ async fn handle_cancel_task<H: RequestHandler>(
     }
 }
 
-async fn handle_subscribe_to_task<H: RequestHandler>(
+async fn handle_post_task_action<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    if let Some(task_id) = id.strip_suffix(":cancel") {
+        return handle_cancel_task_inner(state, task_id.to_string()).await;
+    }
+    if let Some(task_id) = id.strip_suffix(":subscribe") {
+        return handle_subscribe_to_task_inner(state, task_id.to_string()).await;
+    }
+
+    rest_error_response(A2AError::invalid_request("unsupported task action"))
+}
+
+async fn handle_cancel_task_legacy<H: RequestHandler>(
+    State(state): State<RestState<H>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    handle_cancel_task_inner(state, id).await
+}
+
+async fn handle_subscribe_to_task_inner<H: RequestHandler>(
+    state: RestState<H>,
+    id: String,
+) -> axum::response::Response {
     let params = ServiceParams::new();
     let req = SubscribeToTaskRequest { id, tenant: None };
     match state.handler.subscribe_to_task(&params, req).await {
         Ok(stream) => sse::sse_from_stream(stream).into_response(),
         Err(e) => rest_error_response(e),
     }
+}
+
+async fn handle_subscribe_to_task_legacy<H: RequestHandler>(
+    State(state): State<RestState<H>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    handle_subscribe_to_task_inner(state, id).await
+}
+
+#[derive(Deserialize)]
+pub struct ListPushConfigsQuery {
+    #[serde(default, rename = "pageSize")]
+    pub page_size: Option<i32>,
+
+    #[serde(default, rename = "pageToken")]
+    pub page_token: Option<String>,
 }
 
 async fn handle_create_push_config<H: RequestHandler>(
@@ -212,12 +330,13 @@ async fn handle_get_push_config<H: RequestHandler>(
 async fn handle_list_push_configs<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
+    Query(query): Query<ListPushConfigsQuery>,
 ) -> impl IntoResponse {
     let params = ServiceParams::new();
     let req = ListTaskPushNotificationConfigsRequest {
         task_id: id,
-        page_size: None,
-        page_token: None,
+        page_size: query.page_size,
+        page_token: query.page_token,
         tenant: None,
     };
     match state.handler.list_push_configs(&params, req).await {
@@ -254,18 +373,84 @@ async fn handle_get_extended_agent_card<H: RequestHandler>(
 }
 
 fn rest_error_response(err: A2AError) -> axum::response::Response {
-    let status = err.http_status_code();
-    let body = serde_json::json!({
-        "error": {
-            "code": err.code,
-            "message": err.message,
+    let status =
+        StatusCode::from_u16(err.http_status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let reason = rest_error_reason(err.code);
+    let grpc_status = rest_grpc_status(err.code);
+
+    let mut metadata = HashMap::from([("timestamp".to_string(), Utc::now().to_rfc3339())]);
+    let mut extra_details = serde_json::Map::new();
+
+    if let Some(details) = err.details {
+        for (key, value) in details {
+            if let Some(as_string) = value.as_str() {
+                metadata.insert(key, as_string.to_string());
+            } else {
+                extra_details.insert(key, value);
+            }
         }
-    });
-    (
-        StatusCode::from_u16(status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
-        Json(body),
-    )
-        .into_response()
+    }
+
+    let mut details = vec![
+        serde_json::to_value(RestErrorInfo {
+            type_url: REST_ERROR_INFO_TYPE_URL,
+            reason,
+            domain: REST_ERROR_DOMAIN,
+            metadata,
+        })
+        .expect("rest error info should serialize"),
+    ];
+
+    if !extra_details.is_empty() {
+        details.push(Value::Object(extra_details));
+    }
+
+    let body = RestErrorEnvelope {
+        error: RestErrorStatus {
+            code: status.as_u16(),
+            status: grpc_status,
+            message: err.message,
+            details,
+        },
+    };
+
+    (status, Json(body)).into_response()
+}
+
+fn rest_error_reason(code: i32) -> &'static str {
+    match code {
+        error_code::TASK_NOT_FOUND => "TASK_NOT_FOUND",
+        error_code::TASK_NOT_CANCELABLE => "TASK_NOT_CANCELABLE",
+        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED => "PUSH_NOTIFICATION_NOT_SUPPORTED",
+        error_code::UNSUPPORTED_OPERATION => "UNSUPPORTED_OPERATION",
+        error_code::CONTENT_TYPE_NOT_SUPPORTED => "UNSUPPORTED_CONTENT_TYPE",
+        error_code::INVALID_AGENT_RESPONSE => "INVALID_AGENT_RESPONSE",
+        error_code::EXTENDED_CARD_NOT_CONFIGURED => "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+        error_code::EXTENSION_SUPPORT_REQUIRED => "EXTENSION_SUPPORT_REQUIRED",
+        error_code::VERSION_NOT_SUPPORTED => "VERSION_NOT_SUPPORTED",
+        error_code::PARSE_ERROR => "PARSE_ERROR",
+        error_code::INVALID_REQUEST => "INVALID_REQUEST",
+        error_code::METHOD_NOT_FOUND => "METHOD_NOT_FOUND",
+        error_code::INVALID_PARAMS => "INVALID_PARAMS",
+        _ => "INTERNAL_ERROR",
+    }
+}
+
+fn rest_grpc_status(code: i32) -> &'static str {
+    match code {
+        error_code::TASK_NOT_FOUND | error_code::METHOD_NOT_FOUND => "NOT_FOUND",
+        error_code::TASK_NOT_CANCELABLE
+        | error_code::EXTENDED_CARD_NOT_CONFIGURED
+        | error_code::EXTENSION_SUPPORT_REQUIRED => "FAILED_PRECONDITION",
+        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED
+        | error_code::UNSUPPORTED_OPERATION
+        | error_code::VERSION_NOT_SUPPORTED => "UNIMPLEMENTED",
+        error_code::CONTENT_TYPE_NOT_SUPPORTED
+        | error_code::PARSE_ERROR
+        | error_code::INVALID_REQUEST
+        | error_code::INVALID_PARAMS => "INVALID_ARGUMENT",
+        _ => "INTERNAL",
+    }
 }
 
 #[cfg(test)]
@@ -345,7 +530,27 @@ mod tests {
             }
         });
         let req = Request::builder()
-            .uri("/message/send")
+            .uri(REST_SEND_MESSAGE_PATH)
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_send_message_legacy_alias() {
+        let app = make_app();
+        let body = serde_json::json!({
+            "message": {
+                "messageId": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}]
+            }
+        });
+        let req = Request::builder()
+            .uri(REST_SEND_MESSAGE_LEGACY_PATH)
             .method("POST")
             .header("content-type", "application/json")
             .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -385,7 +590,7 @@ mod tests {
     async fn test_cancel_task_not_found() {
         let app = make_app();
         let req = Request::builder()
-            .uri("/tasks/nonexistent/cancel")
+            .uri("/tasks/nonexistent:cancel")
             .method("POST")
             .header("content-type", "application/json")
             .body(Body::empty())
@@ -401,7 +606,7 @@ mod tests {
             "url": "http://example.com/callback"
         });
         let req = Request::builder()
-            .uri("/tasks/t1/push-configs")
+            .uri("/tasks/t1/pushNotificationConfigs")
             .method("POST")
             .header("content-type", "application/json")
             .body(Body::from(serde_json::to_string(&body).unwrap()))
@@ -414,7 +619,7 @@ mod tests {
     async fn test_get_extended_agent_card() {
         let app = make_app();
         let req = Request::builder()
-            .uri("/agent-card/extended")
+            .uri(REST_EXTENDED_AGENT_CARD_PATH)
             .method("GET")
             .body(Body::empty())
             .unwrap();
@@ -427,6 +632,12 @@ mod tests {
         let resp = rest_error_response(A2AError::task_not_found("t1"));
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(payload["error"]["code"], 404);
+        assert_eq!(payload["error"]["status"], "NOT_FOUND");
+        assert_eq!(payload["error"]["details"][0]["reason"], "TASK_NOT_FOUND");
+
         let resp = rest_error_response(A2AError::internal("boom"));
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
@@ -438,8 +649,8 @@ mod tests {
     async fn test_subscribe_to_task_not_found() {
         let app = make_app();
         let req = Request::builder()
-            .uri("/tasks/nonexistent/subscribe")
-            .method("POST")
+            .uri("/tasks/nonexistent:subscribe")
+            .method("GET")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
@@ -457,7 +668,7 @@ mod tests {
             }
         });
         let req = Request::builder()
-            .uri("/message/stream")
+            .uri(REST_STREAM_MESSAGE_PATH)
             .method("POST")
             .header("content-type", "application/json")
             .header("accept", "text/event-stream")
@@ -471,7 +682,7 @@ mod tests {
     async fn test_get_push_config_not_found() {
         let app = make_app();
         let req = Request::builder()
-            .uri("/tasks/t1/push-configs/cfg1")
+            .uri("/tasks/t1/pushNotificationConfigs/cfg1")
             .method("GET")
             .body(Body::empty())
             .unwrap();
@@ -484,7 +695,7 @@ mod tests {
     async fn test_list_push_configs() {
         let app = make_app();
         let req = Request::builder()
-            .uri("/tasks/t1/push-configs")
+            .uri("/tasks/t1/pushNotificationConfigs")
             .method("GET")
             .body(Body::empty())
             .unwrap();
@@ -496,7 +707,7 @@ mod tests {
     async fn test_delete_push_config() {
         let app = make_app();
         let req = Request::builder()
-            .uri("/tasks/t1/push-configs/cfg1")
+            .uri("/tasks/t1/pushNotificationConfigs/cfg1")
             .method("DELETE")
             .body(Body::empty())
             .unwrap();
@@ -508,7 +719,7 @@ mod tests {
     async fn test_list_tasks_with_query_params() {
         let app = make_app();
         let req = Request::builder()
-            .uri("/tasks?contextId=c1&pageSize=5&pageToken=tok&historyLength=3")
+            .uri("/tasks?contextId=c1&pageSize=5&pageToken=tok&historyLength=3&includeArtifacts=true&statusTimestampAfter=2025-01-01T00:00:00Z")
             .method("GET")
             .body(Body::empty())
             .unwrap();
@@ -529,7 +740,7 @@ mod tests {
             }
         });
         let req = Request::builder()
-            .uri("/message/send")
+            .uri(REST_SEND_MESSAGE_PATH)
             .method("POST")
             .header("content-type", "application/json")
             .body(Body::from(serde_json::to_string(&body).unwrap()))

--- a/examples/helloworld/tests/transports_e2e.rs
+++ b/examples/helloworld/tests/transports_e2e.rs
@@ -312,6 +312,19 @@ async fn rest_transport_end_to_end() {
         .unwrap();
     assert_eq!(task.id, "task-1");
 
+    let not_found = transport
+        .get_task(
+            &ServiceParams::new(),
+            &GetTaskRequest {
+                id: "missing".to_string(),
+                history_length: None,
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(not_found.code, error_code::TASK_NOT_FOUND);
+
     let list = transport
         .list_tasks(
             &ServiceParams::new(),
@@ -343,6 +356,19 @@ async fn rest_transport_end_to_end() {
         .unwrap();
     assert_eq!(canceled.status.state, TaskState::Canceled);
 
+    let cancel_missing = transport
+        .cancel_task(
+            &ServiceParams::new(),
+            &CancelTaskRequest {
+                id: "missing".to_string(),
+                metadata: None,
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(cancel_missing.code, error_code::TASK_NOT_FOUND);
+
     let subscribed = transport
         .subscribe_to_task(
             &ServiceParams::new(),
@@ -369,6 +395,19 @@ async fn rest_transport_end_to_end() {
         .unwrap();
     assert_eq!(created.task_id, "task-1");
 
+    let created_missing = transport
+        .create_push_config(
+            &ServiceParams::new(),
+            &CreateTaskPushNotificationConfigRequest {
+                task_id: "missing".to_string(),
+                config: sample_push_config("cfg-1").config,
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(created_missing.code, error_code::TASK_NOT_FOUND);
+
     let fetched = transport
         .get_push_config(
             &ServiceParams::new(),
@@ -381,6 +420,19 @@ async fn rest_transport_end_to_end() {
         .await
         .unwrap();
     assert_eq!(fetched.config.id.as_deref(), Some("cfg-1"));
+
+    let fetched_missing = transport
+        .get_push_config(
+            &ServiceParams::new(),
+            &GetTaskPushNotificationConfigRequest {
+                task_id: "task-1".to_string(),
+                id: "missing".to_string(),
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(fetched_missing.code, error_code::TASK_NOT_FOUND);
 
     let configs = transport
         .list_push_configs(
@@ -407,6 +459,19 @@ async fn rest_transport_end_to_end() {
         )
         .await
         .unwrap();
+
+    let delete_missing = transport
+        .delete_push_config(
+            &ServiceParams::new(),
+            &DeleteTaskPushNotificationConfigRequest {
+                task_id: "task-1".to_string(),
+                id: "missing".to_string(),
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(delete_missing.code, error_code::TASK_NOT_FOUND);
 
     let resolver = AgentCardResolver::new(Some(Client::new()));
     let card = resolver.resolve(&base_url).await.unwrap();


### PR DESCRIPTION
## Summary

Align the Rust HTTP+JSON binding with the A2A 1.0 and cross-SDK REST contract.

- switch the Rust REST client to canonical HTTP+JSON routes such as `/message:send`, `/tasks/{id}:cancel`, `/tasks/{id}:subscribe`, `/tasks/{id}/pushNotificationConfigs`, and `/extendedAgentCard`
- preserve structured A2A error codes when the Rust REST client receives non-2xx responses
- serve canonical HTTP+JSON routes from the Rust REST server and emit structured `google.rpc.Status`-style error payloads with `ErrorInfo` details
- keep the older slash-style REST routes on the server as compatibility aliases while clients migrate
- add regression coverage for REST error parsing and end-to-end transport behavior

## Validation

- `cargo fmt --all`
- `cargo test --workspace`

## Context

This is the upstream fix needed to convert the CSIT Rust <-> Go REST legs from documented incompatibilities into true interoperability passes.
