### PR TITLE
fix: normalize gRPC agent card URLs

### DIFF
--- a/a2a-grpc/src/errors.rs
+++ b/a2a-grpc/src/errors.rs
@@ -117,6 +117,38 @@ mod tests {
     }
 
     #[test]
+    fn test_additional_a2a_error_to_status_mappings() {
+        let cases = [
+            (
+                error_code::EXTENDED_CARD_NOT_CONFIGURED,
+                tonic::Code::Unimplemented,
+            ),
+            (
+                error_code::EXTENSION_SUPPORT_REQUIRED,
+                tonic::Code::FailedPrecondition,
+            ),
+            (
+                error_code::VERSION_NOT_SUPPORTED,
+                tonic::Code::FailedPrecondition,
+            ),
+        ];
+
+        for (code, expected_grpc) in cases {
+            let err = A2AError::new(code, "test");
+            let status = a2a_error_to_status(&err);
+            assert_eq!(status.code(), expected_grpc);
+        }
+    }
+
+    #[test]
+    fn test_unknown_status_maps_to_internal_error() {
+        let status = tonic::Status::new(tonic::Code::Cancelled, "cancelled");
+        let err = status_to_a2a_error(&status);
+        assert_eq!(err.code, error_code::INTERNAL_ERROR);
+        assert_eq!(err.message, "cancelled");
+    }
+
+    #[test]
     fn test_message_preserved() {
         let err = A2AError::new(error_code::TASK_NOT_FOUND, "task xyz not found");
         let status = a2a_error_to_status(&err);

--- a/a2a-pb/src/pbconv.rs
+++ b/a2a-pb/src/pbconv.rs
@@ -835,7 +835,7 @@ pub fn from_proto_stream_response(r: &proto::StreamResponse) -> Option<StreamRes
 
 pub fn to_proto_agent_interface(i: &AgentInterface) -> proto::AgentInterface {
     proto::AgentInterface {
-        url: i.url.clone(),
+        url: i.wire_url(),
         protocol_binding: i.protocol_binding.clone(),
         tenant: i.tenant.clone().unwrap_or_default(),
         protocol_version: i.protocol_version.clone(),
@@ -843,12 +843,10 @@ pub fn to_proto_agent_interface(i: &AgentInterface) -> proto::AgentInterface {
 }
 
 pub fn from_proto_agent_interface(i: &proto::AgentInterface) -> AgentInterface {
-    AgentInterface {
-        url: i.url.clone(),
-        protocol_binding: i.protocol_binding.clone(),
-        protocol_version: i.protocol_version.clone(),
-        tenant: empty_to_none(&i.tenant),
-    }
+    let mut iface = AgentInterface::new(i.url.clone(), i.protocol_binding.clone());
+    iface.protocol_version = i.protocol_version.clone();
+    iface.tenant = empty_to_none(&i.tenant);
+    iface
 }
 
 pub fn to_proto_agent_provider(p: &AgentProvider) -> proto::AgentProvider {
@@ -2214,6 +2212,25 @@ mod tests {
         let proto = to_proto_agent_interface(&iface);
         let back = from_proto_agent_interface(&proto);
         assert_eq!(iface, back);
+    }
+
+    #[test]
+    fn test_agent_interface_roundtrip_normalizes_grpc_http_scheme() {
+        let iface = AgentInterface {
+            url: "http://localhost:50051".to_string(),
+            protocol_binding: TRANSPORT_PROTOCOL_GRPC.to_string(),
+            protocol_version: "1.0".to_string(),
+            tenant: Some("ten".to_string()),
+        };
+
+        let proto = to_proto_agent_interface(&iface);
+        assert_eq!(proto.url, "localhost:50051");
+
+        let back = from_proto_agent_interface(&proto);
+        assert_eq!(back.url, "localhost:50051");
+        assert_eq!(back.protocol_binding, TRANSPORT_PROTOCOL_GRPC);
+        assert_eq!(back.protocol_version, "1.0");
+        assert_eq!(back.tenant.as_deref(), Some("ten"));
     }
 
     #[test]

--- a/a2a/src/agent_card.rs
+++ b/a2a/src/agent_card.rs
@@ -1,10 +1,10 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use crate::types::{ProtocolVersion, TransportProtocol};
+use crate::types::{ProtocolVersion, TRANSPORT_PROTOCOL_GRPC, TransportProtocol};
 
 // ---------------------------------------------------------------------------
 // AgentCard
@@ -56,25 +56,76 @@ where
 // ---------------------------------------------------------------------------
 
 /// A URL + protocol binding combination for reaching the agent.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq)]
 pub struct AgentInterface {
     pub url: String,
     pub protocol_binding: TransportProtocol,
     pub protocol_version: ProtocolVersion,
-
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tenant: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentInterfaceSerde {
+    url: String,
+    protocol_binding: TransportProtocol,
+    protocol_version: ProtocolVersion,
+    #[serde(default)]
+    tenant: Option<String>,
+}
+
+fn normalize_agent_interface_url(url: String, protocol_binding: &str) -> String {
+    if protocol_binding.eq_ignore_ascii_case(TRANSPORT_PROTOCOL_GRPC) {
+        if let Some(stripped) = url.strip_prefix("http://") {
+            return stripped.to_string();
+        }
+    }
+
+    url
 }
 
 impl AgentInterface {
     pub fn new(url: impl Into<String>, protocol_binding: impl Into<String>) -> Self {
+        let protocol_binding = protocol_binding.into();
         AgentInterface {
-            url: url.into(),
-            protocol_binding: protocol_binding.into(),
+            url: normalize_agent_interface_url(url.into(), &protocol_binding),
+            protocol_binding,
             protocol_version: crate::VERSION.to_string(),
             tenant: None,
         }
+    }
+
+    pub fn wire_url(&self) -> String {
+        normalize_agent_interface_url(self.url.clone(), &self.protocol_binding)
+    }
+}
+
+impl Serialize for AgentInterface {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer
+            .serialize_struct("AgentInterface", if self.tenant.is_some() { 4 } else { 3 })?;
+        state.serialize_field("url", &self.wire_url())?;
+        state.serialize_field("protocolBinding", &self.protocol_binding)?;
+        state.serialize_field("protocolVersion", &self.protocol_version)?;
+        if let Some(tenant) = &self.tenant {
+            state.serialize_field("tenant", tenant)?;
+        }
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for AgentInterface {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = AgentInterfaceSerde::deserialize(deserializer)?;
+
+        Ok(Self {
+            url: normalize_agent_interface_url(raw.url, &raw.protocol_binding),
+            protocol_binding: raw.protocol_binding,
+            protocol_version: raw.protocol_version,
+            tenant: raw.tenant,
+        })
     }
 }
 
@@ -443,6 +494,81 @@ mod tests {
         assert_eq!(iface.url, "http://localhost:3000");
         assert_eq!(iface.protocol_binding, "JSONRPC");
         assert!(!iface.protocol_version.is_empty());
+    }
+
+    #[test]
+    fn test_agent_interface_new_normalizes_grpc_http_scheme() {
+        let iface = AgentInterface::new("http://localhost:50051", TRANSPORT_PROTOCOL_GRPC);
+        assert_eq!(iface.url, "localhost:50051");
+        assert_eq!(iface.protocol_binding, TRANSPORT_PROTOCOL_GRPC);
+    }
+
+    #[test]
+    fn test_agent_interface_new_preserves_grpc_https_scheme() {
+        let iface = AgentInterface::new("https://localhost:50051", TRANSPORT_PROTOCOL_GRPC);
+        assert_eq!(iface.url, "https://localhost:50051");
+        assert_eq!(iface.protocol_binding, TRANSPORT_PROTOCOL_GRPC);
+    }
+
+    #[test]
+    fn test_agent_interface_serde_normalizes_grpc_http_scheme() {
+        let iface = AgentInterface {
+            url: "http://localhost:50051".to_string(),
+            protocol_binding: TRANSPORT_PROTOCOL_GRPC.to_string(),
+            protocol_version: crate::VERSION.to_string(),
+            tenant: Some("tenant-a".to_string()),
+        };
+
+        let json = serde_json::to_string(&iface).unwrap();
+        assert!(json.contains("\"url\":\"localhost:50051\""));
+
+        let back: AgentInterface = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.url, "localhost:50051");
+        assert_eq!(back.protocol_binding, TRANSPORT_PROTOCOL_GRPC);
+        assert_eq!(back.tenant.as_deref(), Some("tenant-a"));
+    }
+
+    #[test]
+    fn test_agent_card_deserialize_null_skills_as_default() {
+        let json = serde_json::json!({
+            "name": "Test Agent",
+            "description": "A test agent",
+            "version": "1.0.0",
+            "supportedInterfaces": [
+                {
+                    "url": "http://localhost:3000",
+                    "protocolBinding": "JSONRPC",
+                    "protocolVersion": crate::VERSION
+                }
+            ],
+            "capabilities": {},
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain"],
+            "skills": null
+        });
+
+        let card: AgentCard = serde_json::from_value(json).unwrap();
+        assert!(card.skills.is_empty());
+    }
+
+    #[test]
+    fn test_security_scheme_deserialize_unknown_variant_errors() {
+        let err = serde_json::from_value::<SecurityScheme>(serde_json::json!({
+            "unknown": {"value": true}
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown security scheme variant"));
+    }
+
+    #[test]
+    fn test_oauth_flows_deserialize_unknown_variant_errors() {
+        let err = serde_json::from_value::<OAuthFlows>(serde_json::json!({
+            "unknown": {"tokenUrl": "https://example.com/token"}
+        }))
+        .unwrap_err();
+
+        assert!(err.to_string().contains("unknown OAuth flow variant"));
     }
 
     #[test]

--- a/a2a/src/errors.rs
+++ b/a2a/src/errors.rs
@@ -210,6 +210,28 @@ mod tests {
     }
 
     #[test]
+    fn test_http_status_codes_for_remaining_a2a_mappings() {
+        assert_eq!(
+            A2AError::push_notification_not_supported().http_status_code(),
+            400
+        );
+        assert_eq!(
+            A2AError::unsupported_operation("nope").http_status_code(),
+            400
+        );
+        assert_eq!(
+            A2AError::version_not_supported("9.9").http_status_code(),
+            400
+        );
+        assert_eq!(A2AError::parse_error("bad").http_status_code(), 400);
+        assert_eq!(A2AError::invalid_request("bad").http_status_code(), 400);
+        assert_eq!(
+            A2AError::method_not_found("missing").http_status_code(),
+            404
+        );
+    }
+
+    #[test]
     fn test_to_jsonrpc_error() {
         let e = A2AError::task_not_found("t1");
         let rpc = e.to_jsonrpc_error();


### PR DESCRIPTION
## Summary

This completes the remaining Rust-side gRPC interop fix by normalizing published gRPC agent-card interface URLs.

- canonicalize `GRPC` interface URLs by stripping plaintext `http://` on construction and wire serialization/deserialization
- apply the same normalization in protobuf agent interface conversion so JSON and protobuf card paths stay aligned
- add regression tests for gRPC interface normalization and related error/status mappings used to keep overall line coverage above the current target

## Context

The previously released Rust gRPC fix made the client tolerant of bare `host:port` endpoints. The remaining gap was on the publication side: Rust still emitted `http://host:port` in gRPC agent cards, which Go rejects for gRPC transport discovery. This change fixes that outbound card representation.

`https://` URLs are intentionally preserved so TLS intent is not discarded.

## Testing

- `cargo fmt --all --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo llvm-cov --workspace --summary-only --ignore-filename-regex gen/` (`95.08%` line coverage)