### PR TITLE
feat(server): support push configs and gRPC list interop

### DIFF
--- a/a2a-grpc/tests/e2e.rs
+++ b/a2a-grpc/tests/e2e.rs
@@ -8,7 +8,7 @@ use a2a::*;
 use a2a_client::{Transport, TransportFactory};
 use a2a_grpc::{GrpcHandler, GrpcTransport, GrpcTransportFactory};
 use a2a_pb::proto::a2a_service_server::A2aServiceServer;
-use a2a_server::{RequestHandler, ServiceParams};
+use a2a_server::{DefaultRequestHandler, InMemoryTaskStore, RequestHandler, ServiceParams};
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures::stream::{self, BoxStream};
@@ -80,6 +80,8 @@ fn sample_agent_card() -> AgentCard {
 }
 
 struct TestHandler;
+
+struct StoredTaskExecutor;
 
 #[async_trait]
 impl RequestHandler for TestHandler {
@@ -245,8 +247,79 @@ impl RequestHandler for TestHandler {
     }
 }
 
+impl a2a_server::AgentExecutor for StoredTaskExecutor {
+    fn execute(
+        &self,
+        ctx: a2a_server::ExecutorContext,
+    ) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
+        let response = StreamResponse::Task(Task {
+            id: ctx.task_id.clone(),
+            context_id: ctx.context_id.clone(),
+            status: TaskStatus {
+                state: TaskState::Completed,
+                message: Some(Message {
+                    message_id: "stored-task-response".to_string(),
+                    context_id: Some(ctx.context_id.clone()),
+                    task_id: Some(ctx.task_id.clone()),
+                    role: Role::Agent,
+                    parts: vec![Part::text("stored-task-done")],
+                    metadata: None,
+                    extensions: None,
+                    reference_task_ids: None,
+                }),
+                timestamp: None,
+            },
+            artifacts: None,
+            history: ctx.message.clone().map(|message| vec![message]),
+            metadata: None,
+        });
+
+        Box::pin(stream::once(async move { Ok(response) }))
+    }
+
+    fn cancel(
+        &self,
+        ctx: a2a_server::ExecutorContext,
+    ) -> BoxStream<'static, Result<StreamResponse, A2AError>> {
+        let response = StreamResponse::Task(Task {
+            id: ctx.task_id.clone(),
+            context_id: ctx.context_id.clone(),
+            status: TaskStatus {
+                state: TaskState::Canceled,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        });
+
+        Box::pin(stream::once(async move { Ok(response) }))
+    }
+}
+
 async fn spawn_grpc_server() -> (String, tokio::task::JoinHandle<()>) {
     let handler = Arc::new(TestHandler);
+    let service = A2aServiceServer::new(GrpcHandler::new(handler));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let incoming = TcpListenerStream::new(listener);
+    let handle = tokio::spawn(async move {
+        Server::builder()
+            .add_service(service)
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    (format!("http://{addr}"), handle)
+}
+
+async fn spawn_default_handler_grpc_server() -> (String, tokio::task::JoinHandle<()>) {
+    let handler = Arc::new(DefaultRequestHandler::new(
+        StoredTaskExecutor,
+        InMemoryTaskStore::new(),
+    ));
     let service = A2aServiceServer::new(GrpcHandler::new(handler));
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -498,6 +571,54 @@ async fn grpc_transport_accepts_bare_host_port_endpoints() {
         .await
         .unwrap();
     assert!(matches!(response, SendMessageResponse::Task(_)));
+
+    transport.destroy().await.unwrap();
+    handle.abort();
+}
+
+#[tokio::test]
+async fn grpc_transport_treats_zero_page_size_as_unset() {
+    let (endpoint, handle) = spawn_default_handler_grpc_server().await;
+    let transport = GrpcTransport::connect(endpoint).await.unwrap();
+
+    let sent = transport
+        .send_message(
+            &ServiceParams::new(),
+            &SendMessageRequest {
+                message: Message::new(Role::User, vec![Part::text("hello")]),
+                configuration: None,
+                metadata: None,
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let task = match sent {
+        SendMessageResponse::Task(task) => task,
+        SendMessageResponse::Message(_) => panic!("expected task response"),
+    };
+
+    let listed = transport
+        .list_tasks(
+            &ServiceParams::new(),
+            &ListTasksRequest {
+                context_id: Some(task.context_id.clone()),
+                status: None,
+                page_size: Some(0),
+                page_token: None,
+                history_length: None,
+                status_timestamp_after: None,
+                include_artifacts: Some(false),
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(listed.tasks.len(), 1);
+    assert_eq!(listed.tasks[0].id, task.id);
+    assert_eq!(listed.page_size, 50);
 
     transport.destroy().await.unwrap();
     handle.abort();

--- a/a2a-pb/src/pbconv.rs
+++ b/a2a-pb/src/pbconv.rs
@@ -111,6 +111,10 @@ fn empty_to_none(s: &str) -> Option<String> {
     }
 }
 
+fn non_positive_to_none(value: Option<i32>) -> Option<i32> {
+    value.filter(|value| *value > 0)
+}
+
 // ---------------------------------------------------------------------------
 // Role
 // ---------------------------------------------------------------------------
@@ -519,7 +523,7 @@ pub fn from_proto_list_tasks_request(r: &proto::ListTasksRequest) -> ListTasksRe
         } else {
             Some(from_proto_task_state(r.status))
         },
-        page_size: r.page_size,
+        page_size: non_positive_to_none(r.page_size),
         page_token: empty_to_none(&r.page_token),
         history_length: r.history_length,
         status_timestamp_after: r
@@ -1624,6 +1628,24 @@ mod tests {
         assert_eq!(req.history_length, back.history_length);
         assert_eq!(req.include_artifacts, back.include_artifacts);
         assert_eq!(req.tenant, back.tenant);
+    }
+
+    #[test]
+    fn test_from_proto_list_tasks_request_treats_zero_page_size_as_unset() {
+        let proto = proto::ListTasksRequest {
+            tenant: String::new(),
+            context_id: "ctx-1".to_string(),
+            status: 0,
+            page_size: Some(0),
+            page_token: String::new(),
+            history_length: None,
+            status_timestamp_after: None,
+            include_artifacts: Some(false),
+        };
+
+        let back = from_proto_list_tasks_request(&proto);
+        assert_eq!(back.context_id.as_deref(), Some("ctx-1"));
+        assert_eq!(back.page_size, None);
     }
 
     #[test]

--- a/a2a-server/src/handler.rs
+++ b/a2a-server/src/handler.rs
@@ -83,6 +83,7 @@ pub trait RequestHandler: Send + Sync + 'static {
 pub struct DefaultRequestHandler {
     executor: Box<dyn crate::AgentExecutor>,
     task_store: Box<dyn crate::TaskStore>,
+    push_config_store: Option<Box<dyn crate::PushConfigStore>>,
     capabilities: AgentCapabilities,
 }
 
@@ -91,13 +92,29 @@ impl DefaultRequestHandler {
         DefaultRequestHandler {
             executor: Box::new(executor),
             task_store: Box::new(task_store),
+            push_config_store: None,
             capabilities: AgentCapabilities::default(),
         }
+    }
+
+    pub fn with_push_config_store(
+        mut self,
+        push_config_store: impl crate::PushConfigStore,
+    ) -> Self {
+        self.push_config_store = Some(Box::new(push_config_store));
+        self.capabilities.push_notifications = Some(true);
+        self
     }
 
     pub fn with_capabilities(mut self, capabilities: AgentCapabilities) -> Self {
         self.capabilities = capabilities;
         self
+    }
+
+    fn push_config_store(&self) -> Result<&dyn crate::PushConfigStore, A2AError> {
+        self.push_config_store
+            .as_deref()
+            .ok_or_else(A2AError::push_notification_not_supported)
     }
 }
 
@@ -298,33 +315,75 @@ impl RequestHandler for DefaultRequestHandler {
     async fn create_push_config(
         &self,
         _params: &ServiceParams,
-        _req: CreateTaskPushNotificationConfigRequest,
+        req: CreateTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        Err(A2AError::push_notification_not_supported())
+        let saved = self
+            .push_config_store()?
+            .save(&req.task_id, req.config)
+            .await?;
+        Ok(TaskPushNotificationConfig {
+            task_id: req.task_id,
+            config: saved,
+            tenant: req.tenant,
+        })
     }
 
     async fn get_push_config(
         &self,
         _params: &ServiceParams,
-        _req: GetTaskPushNotificationConfigRequest,
+        req: GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        Err(A2AError::push_notification_not_supported())
+        let config = self.push_config_store()?.get(&req.task_id, &req.id).await?;
+        Ok(TaskPushNotificationConfig {
+            task_id: req.task_id,
+            config,
+            tenant: req.tenant,
+        })
     }
 
     async fn list_push_configs(
         &self,
         _params: &ServiceParams,
-        _req: ListTaskPushNotificationConfigsRequest,
+        req: ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
-        Err(A2AError::push_notification_not_supported())
+        let mut configs = self.push_config_store()?.list(&req.task_id).await?;
+        configs.sort_by(|left, right| left.id.cmp(&right.id));
+
+        let page_size = match req.page_size {
+            Some(size) if size > 0 => size as usize,
+            _ => 50,
+        };
+        let start = req
+            .page_token
+            .as_deref()
+            .and_then(|token| token.parse::<usize>().ok())
+            .unwrap_or(0)
+            .min(configs.len());
+        let end = (start + page_size).min(configs.len());
+        let next_page_token = (end < configs.len()).then(|| end.to_string());
+
+        Ok(ListTaskPushNotificationConfigsResponse {
+            configs: configs[start..end]
+                .iter()
+                .cloned()
+                .map(|config| TaskPushNotificationConfig {
+                    task_id: req.task_id.clone(),
+                    config,
+                    tenant: req.tenant.clone(),
+                })
+                .collect(),
+            next_page_token,
+        })
     }
 
     async fn delete_push_config(
         &self,
         _params: &ServiceParams,
-        _req: DeleteTaskPushNotificationConfigRequest,
+        req: DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
-        Err(A2AError::push_notification_not_supported())
+        self.push_config_store()?
+            .delete(&req.task_id, &req.id)
+            .await
     }
 
     async fn get_extended_agent_card(
@@ -342,6 +401,7 @@ impl RequestHandler for DefaultRequestHandler {
 mod tests {
     use super::*;
     use crate::executor::ExecutorContext;
+    use crate::push::InMemoryPushConfigStore;
     use crate::task_store::InMemoryTaskStore;
     use futures::stream;
 
@@ -389,6 +449,11 @@ mod tests {
 
     fn make_handler() -> DefaultRequestHandler {
         DefaultRequestHandler::new(EchoExecutor, InMemoryTaskStore::new())
+    }
+
+    fn make_handler_with_push_configs() -> DefaultRequestHandler {
+        DefaultRequestHandler::new(EchoExecutor, InMemoryTaskStore::new())
+            .with_push_config_store(InMemoryPushConfigStore::new())
     }
 
     fn make_message() -> Message {
@@ -568,7 +633,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_push_config_not_supported() {
+    async fn test_push_config_not_supported_without_store() {
         let handler = make_handler();
         let params = ServiceParams::new();
         let result = handler
@@ -590,6 +655,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_push_config_crud_with_store() {
+        let handler = make_handler_with_push_configs();
+        let params = ServiceParams::new();
+
+        let created = handler
+            .create_push_config(
+                &params,
+                CreateTaskPushNotificationConfigRequest {
+                    task_id: "t1".into(),
+                    config: PushNotificationConfig {
+                        url: "https://example.com/first".into(),
+                        id: Some("cfg-1".into()),
+                        token: None,
+                        authentication: None,
+                    },
+                    tenant: Some("tenant-a".into()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(created.config.id.as_deref(), Some("cfg-1"));
+
+        handler
+            .create_push_config(
+                &params,
+                CreateTaskPushNotificationConfigRequest {
+                    task_id: "t1".into(),
+                    config: PushNotificationConfig {
+                        url: "https://example.com/second".into(),
+                        id: Some("cfg-2".into()),
+                        token: None,
+                        authentication: None,
+                    },
+                    tenant: Some("tenant-a".into()),
+                },
+            )
+            .await
+            .unwrap();
+
+        let fetched = handler
+            .get_push_config(
+                &params,
+                GetTaskPushNotificationConfigRequest {
+                    task_id: "t1".into(),
+                    id: "cfg-1".into(),
+                    tenant: Some("tenant-a".into()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(fetched.config.url, "https://example.com/first");
+
+        let first_page = handler
+            .list_push_configs(
+                &params,
+                ListTaskPushNotificationConfigsRequest {
+                    task_id: "t1".into(),
+                    page_size: Some(1),
+                    page_token: Some("0".into()),
+                    tenant: Some("tenant-a".into()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(first_page.configs.len(), 1);
+        assert_eq!(first_page.configs[0].config.id.as_deref(), Some("cfg-1"));
+        assert_eq!(first_page.next_page_token.as_deref(), Some("1"));
+
+        let default_page = handler
+            .list_push_configs(
+                &params,
+                ListTaskPushNotificationConfigsRequest {
+                    task_id: "t1".into(),
+                    page_size: Some(0),
+                    page_token: None,
+                    tenant: Some("tenant-a".into()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(default_page.configs.len(), 2);
+        assert!(default_page.next_page_token.is_none());
+
+        handler
+            .delete_push_config(
+                &params,
+                DeleteTaskPushNotificationConfigRequest {
+                    task_id: "t1".into(),
+                    id: "cfg-1".into(),
+                    tenant: Some("tenant-a".into()),
+                },
+            )
+            .await
+            .unwrap();
+
+        let remaining = handler
+            .list_push_configs(
+                &params,
+                ListTaskPushNotificationConfigsRequest {
+                    task_id: "t1".into(),
+                    page_size: None,
+                    page_token: None,
+                    tenant: Some("tenant-a".into()),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(remaining.configs.len(), 1);
+        assert_eq!(remaining.configs[0].config.id.as_deref(), Some("cfg-2"));
+    }
+
+    #[tokio::test]
     async fn test_extended_agent_card_not_configured() {
         let handler = make_handler();
         let params = ServiceParams::new();
@@ -608,5 +785,11 @@ mod tests {
             extended_agent_card: None,
         });
         assert_eq!(handler.capabilities.streaming, Some(true));
+    }
+
+    #[test]
+    fn test_with_push_config_store_enables_push_capability() {
+        let handler = make_handler_with_push_configs();
+        assert_eq!(handler.capabilities.push_notifications, Some(true));
     }
 }

--- a/a2a-server/src/task_store/inmemory.rs
+++ b/a2a-server/src/task_store/inmemory.rs
@@ -84,7 +84,10 @@ impl TaskStore for InMemoryTaskStore {
         tasks.sort_by(|a, b| a.id.cmp(&b.id));
 
         // Apply pagination
-        let page_size = req.page_size.unwrap_or(50) as usize;
+        let page_size = match req.page_size {
+            Some(size) if size > 0 => size as usize,
+            _ => 50,
+        };
         let start = if let Some(ref token) = req.page_token {
             // Simple offset-based pagination
             token.parse::<usize>().unwrap_or(0)
@@ -291,6 +294,31 @@ mod tests {
         };
         let resp2 = store.list(&req2).await.unwrap();
         assert_eq!(resp2.tasks.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_zero_page_size_uses_default_window() {
+        let store = InMemoryTaskStore::new();
+        for i in 0..3 {
+            store
+                .create(make_task(&format!("t{i}"), "c1", TaskState::Submitted))
+                .await
+                .unwrap();
+        }
+
+        let req = ListTasksRequest {
+            context_id: None,
+            status: None,
+            page_size: Some(0),
+            page_token: None,
+            history_length: None,
+            status_timestamp_after: None,
+            include_artifacts: None,
+            tenant: None,
+        };
+        let resp = store.list(&req).await.unwrap();
+        assert_eq!(resp.tasks.len(), 3);
+        assert_eq!(resp.page_size, 50);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- normalize gRPC `ListTasks` page sizes so Go clients sending an unset value as zero still receive the default result window
- add opt-in push-config CRUD support to `DefaultRequestHandler` via `with_push_config_store(...)`
- add protobuf, task-store, handler, and gRPC end-to-end regressions for the interop paths

## Testing

- cargo fmt --all --check
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings