### PR TITLE
fix(interop): align push-config JSON bindings with a2a-go

### DIFF
--- a/a2a-client/src/jsonrpc.rs
+++ b/a2a-client/src/jsonrpc.rs
@@ -6,6 +6,10 @@ use async_trait::async_trait;
 use futures::stream::{self, BoxStream, StreamExt};
 use reqwest::Client;
 
+use crate::push_config_compat::{
+    deserialize_list_task_push_notification_configs_response,
+    deserialize_task_push_notification_config,
+};
 use crate::transport::{ServiceParams, Transport, TransportFactory};
 
 /// JSON-RPC transport implementation.
@@ -22,15 +26,14 @@ impl JsonRpcTransport {
         JsonRpcTransport { client, endpoint }
     }
 
-    async fn call<Req, Resp>(
+    async fn call_value<Req>(
         &self,
         params: &ServiceParams,
         method: &str,
         request_params: &Req,
-    ) -> Result<Resp, A2AError>
+    ) -> Result<serde_json::Value, A2AError>
     where
         Req: ProtoJsonPayload,
-        Resp: ProtoJsonPayload,
     {
         let id = JsonRpcId::String(uuid::Uuid::now_v7().to_string());
         let payload = protojson_conv::to_value(request_params).map_err(|e| {
@@ -63,6 +66,21 @@ impl JsonRpcTransport {
         let result = rpc_response
             .result
             .ok_or_else(|| A2AError::internal("JSON-RPC response missing result"))?;
+
+        Ok(result)
+    }
+
+    async fn call<Req, Resp>(
+        &self,
+        params: &ServiceParams,
+        method: &str,
+        request_params: &Req,
+    ) -> Result<Resp, A2AError>
+    where
+        Req: ProtoJsonPayload,
+        Resp: ProtoJsonPayload,
+    {
+        let result = self.call_value(params, method, request_params).await?;
 
         protojson_conv::from_value(result)
             .map_err(|e| A2AError::internal(format!("failed to deserialize result: {e}")))
@@ -323,7 +341,8 @@ impl Transport for JsonRpcTransport {
         params: &ServiceParams,
         req: &CreateTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        self.call(params, methods::CREATE_PUSH_CONFIG, req).await
+        let result = self.call_value(params, methods::CREATE_PUSH_CONFIG, req).await?;
+        deserialize_task_push_notification_config(result)
     }
 
     async fn get_push_config(
@@ -331,7 +350,8 @@ impl Transport for JsonRpcTransport {
         params: &ServiceParams,
         req: &GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        self.call(params, methods::GET_PUSH_CONFIG, req).await
+        let result = self.call_value(params, methods::GET_PUSH_CONFIG, req).await?;
+        deserialize_task_push_notification_config(result)
     }
 
     async fn list_push_configs(
@@ -339,7 +359,8 @@ impl Transport for JsonRpcTransport {
         params: &ServiceParams,
         req: &ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
-        self.call(params, methods::LIST_PUSH_CONFIGS, req).await
+        let result = self.call_value(params, methods::LIST_PUSH_CONFIGS, req).await?;
+        deserialize_list_task_push_notification_configs_response(result)
     }
 
     async fn delete_push_config(

--- a/a2a-client/src/lib.rs
+++ b/a2a-client/src/lib.rs
@@ -6,6 +6,7 @@ pub mod client;
 pub mod factory;
 pub mod jsonrpc;
 pub mod middleware;
+mod push_config_compat;
 pub mod rest;
 pub mod transport;
 

--- a/a2a-client/src/push_config_compat.rs
+++ b/a2a-client/src/push_config_compat.rs
@@ -1,0 +1,104 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use a2a::*;
+use a2a_pb::protojson_conv;
+use serde_json::Value;
+
+pub(crate) fn deserialize_task_push_notification_config(
+    payload: Value,
+) -> Result<TaskPushNotificationConfig, A2AError> {
+    serde_json::from_value::<TaskPushNotificationConfig>(payload.clone()).or_else(|serde_error| {
+        protojson_conv::from_value(payload).map_err(|protojson_error| {
+            A2AError::internal(format!(
+                "failed to deserialize push-config response: {serde_error}; ProtoJSON fallback failed: {protojson_error}"
+            ))
+        })
+    })
+}
+
+pub(crate) fn deserialize_list_task_push_notification_configs_response(
+    payload: Value,
+) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+    serde_json::from_value::<ListTaskPushNotificationConfigsResponse>(payload.clone()).or_else(
+        |serde_error| {
+            serde_json::from_value::<Vec<TaskPushNotificationConfig>>(payload.clone())
+                .map(|configs| ListTaskPushNotificationConfigsResponse {
+                    configs,
+                    next_page_token: None,
+                })
+                .or_else(|array_error| {
+                    protojson_conv::from_value(payload).map_err(|protojson_error| {
+                        A2AError::internal(format!(
+                            "failed to deserialize push-config list response: {serde_error}; array fallback failed: {array_error}; ProtoJSON fallback failed: {protojson_error}"
+                        ))
+                    })
+                })
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_task_push_config() -> TaskPushNotificationConfig {
+        TaskPushNotificationConfig {
+            task_id: "t1".into(),
+            config: PushNotificationConfig {
+                url: "https://example.invalid/webhook".into(),
+                id: Some("cfg1".into()),
+                token: Some("token-1".into()),
+                authentication: Some(AuthenticationInfo {
+                    scheme: "Bearer".into(),
+                    credentials: Some("secret".into()),
+                }),
+            },
+            tenant: Some("tenant-1".into()),
+        }
+    }
+
+    #[test]
+    fn parses_nested_task_push_config_shape() {
+        let payload = serde_json::to_value(sample_task_push_config()).unwrap();
+        let parsed = deserialize_task_push_notification_config(payload).unwrap();
+        assert_eq!(parsed, sample_task_push_config());
+    }
+
+    #[test]
+    fn falls_back_to_flattened_protojson_task_push_config_shape() {
+        let payload = protojson_conv::to_value(&sample_task_push_config()).unwrap();
+        let parsed = deserialize_task_push_notification_config(payload).unwrap();
+        assert_eq!(parsed, sample_task_push_config());
+    }
+
+    #[test]
+    fn parses_nested_list_task_push_configs_shape() {
+        let response = ListTaskPushNotificationConfigsResponse {
+            configs: vec![sample_task_push_config()],
+            next_page_token: Some("next".into()),
+        };
+        let payload = serde_json::to_value(response.clone()).unwrap();
+        let parsed = deserialize_list_task_push_notification_configs_response(payload).unwrap();
+        assert_eq!(parsed, response);
+    }
+
+    #[test]
+    fn falls_back_to_flattened_protojson_list_task_push_configs_shape() {
+        let response = ListTaskPushNotificationConfigsResponse {
+            configs: vec![sample_task_push_config()],
+            next_page_token: Some("next".into()),
+        };
+        let payload = protojson_conv::to_value(&response).unwrap();
+        let parsed = deserialize_list_task_push_notification_configs_response(payload).unwrap();
+        assert_eq!(parsed, response);
+    }
+
+    #[test]
+    fn falls_back_to_raw_array_list_task_push_configs_shape() {
+        let configs = vec![sample_task_push_config()];
+        let payload = serde_json::to_value(configs.clone()).unwrap();
+        let parsed = deserialize_list_task_push_notification_configs_response(payload).unwrap();
+        assert_eq!(parsed.configs, configs);
+        assert_eq!(parsed.next_page_token, None);
+    }
+}

--- a/a2a-client/src/rest.rs
+++ b/a2a-client/src/rest.rs
@@ -9,6 +9,10 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 
+use crate::push_config_compat::{
+    deserialize_list_task_push_notification_configs_response,
+    deserialize_task_push_notification_config,
+};
 use crate::transport::{ServiceParams, Transport, TransportFactory};
 
 const REST_SEND_MESSAGE_PATH: &str = "/message:send";
@@ -99,15 +103,14 @@ impl RestTransport {
         parse_rest_error(status, &body)
     }
 
-    async fn post_json<Req, Resp>(
+    async fn post_value<Req>(
         &self,
         path: &str,
         params: &ServiceParams,
         body: &Req,
-    ) -> Result<Resp, A2AError>
+    ) -> Result<Value, A2AError>
     where
         Req: ProtoJsonPayload,
-        Resp: ProtoJsonPayload,
     {
         let payload = protojson_conv::to_value(body).map_err(|e| {
             A2AError::internal(format!("failed to serialize request as ProtoJSON: {e}"))
@@ -127,20 +130,32 @@ impl RestTransport {
             .await
             .map_err(|e| A2AError::internal(format!("failed to parse response: {e}")))?;
 
+        Ok(payload)
+    }
+
+    async fn post_json<Req, Resp>(
+        &self,
+        path: &str,
+        params: &ServiceParams,
+        body: &Req,
+    ) -> Result<Resp, A2AError>
+    where
+        Req: ProtoJsonPayload,
+        Resp: ProtoJsonPayload,
+    {
+        let payload = self.post_value(path, params, body).await?;
+
         protojson_conv::from_value(payload).map_err(|e| {
             A2AError::internal(format!("failed to deserialize response as ProtoJSON: {e}"))
         })
     }
 
-    async fn get_json<Resp>(
+    async fn get_value(
         &self,
         path: &str,
         params: &ServiceParams,
         query: &[(String, String)],
-    ) -> Result<Resp, A2AError>
-    where
-        Resp: ProtoJsonPayload,
-    {
+    ) -> Result<Value, A2AError> {
         let resp = self
             .send(self.build_request_with_query(reqwest::Method::GET, path, params, query))
             .await?;
@@ -152,6 +167,20 @@ impl RestTransport {
             .json::<Value>()
             .await
             .map_err(|e| A2AError::internal(format!("failed to parse response: {e}")))?;
+
+        Ok(payload)
+    }
+
+    async fn get_json<Resp>(
+        &self,
+        path: &str,
+        params: &ServiceParams,
+        query: &[(String, String)],
+    ) -> Result<Resp, A2AError>
+    where
+        Resp: ProtoJsonPayload,
+    {
+        let payload = self.get_value(path, params, query).await?;
 
         protojson_conv::from_value(payload).map_err(|e| {
             A2AError::internal(format!("failed to deserialize response as ProtoJSON: {e}"))
@@ -362,12 +391,14 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &CreateTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        self.post_json(
+        let payload = self
+            .post_value(
             &format!("/tasks/{}/pushNotificationConfigs", req.task_id),
             params,
             &req.config,
         )
-        .await
+            .await?;
+        deserialize_task_push_notification_config(payload)
     }
 
     async fn get_push_config(
@@ -375,12 +406,14 @@ impl Transport for RestTransport {
         params: &ServiceParams,
         req: &GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        self.get_json(
+        let payload = self
+            .get_value(
             &format!("/tasks/{}/pushNotificationConfigs/{}", req.task_id, req.id),
             params,
             &[],
         )
-        .await
+            .await?;
+        deserialize_task_push_notification_config(payload)
     }
 
     async fn list_push_configs(
@@ -396,12 +429,14 @@ impl Transport for RestTransport {
             query_parts.push(("pageToken".to_string(), page_token.clone()));
         }
 
-        self.get_json(
+        let payload = self
+            .get_value(
             &format!("/tasks/{}/pushNotificationConfigs", req.task_id),
             params,
             &query_parts,
         )
-        .await
+            .await?;
+        deserialize_list_task_push_notification_configs_response(payload)
     }
 
     async fn delete_push_config(

--- a/a2a-server/src/jsonrpc.rs
+++ b/a2a-server/src/jsonrpc.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use crate::handler::RequestHandler;
 use crate::middleware::ServiceParams;
+use crate::push_config_compat::json_value as compat_json_value;
 use crate::sse;
 
 /// Shared state for the JSON-RPC handler.
@@ -102,7 +103,7 @@ async fn handle_unary_request<H: RequestHandler>(
                 .handler
                 .create_push_config(params, req)
                 .await
-                .and_then(|r| protojson_value(&r)),
+                .and_then(|r| compat_json_value(&r)),
             Err(e) => Err(parse_error(e)),
         },
         methods::GET_PUSH_CONFIG => {
@@ -111,7 +112,7 @@ async fn handle_unary_request<H: RequestHandler>(
                     .handler
                     .get_push_config(params, req)
                     .await
-                    .and_then(|r| protojson_value(&r)),
+                    .and_then(|r| compat_json_value(&r)),
                 Err(e) => Err(parse_error(e)),
             }
         }
@@ -121,7 +122,7 @@ async fn handle_unary_request<H: RequestHandler>(
                     .handler
                     .list_push_configs(params, req)
                     .await
-                    .and_then(|r| protojson_value(&r)),
+                    .and_then(|r| compat_json_value(&r.configs)),
                 Err(e) => Err(parse_error(e)),
             }
         }
@@ -443,8 +444,7 @@ mod tests {
         });
         let resp = post_jsonrpc(app, methods::CREATE_PUSH_CONFIG, params).await;
         assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
-        let result =
-            protojson_conv::from_value::<TaskPushNotificationConfig>(resp.result.unwrap()).unwrap();
+        let result = serde_json::from_value::<TaskPushNotificationConfig>(resp.result.unwrap()).unwrap();
         assert_eq!(result.task_id, "t1");
         assert_eq!(result.config.id.as_deref(), Some("cfg1"));
         assert_eq!(result.config.url, "http://example.com/callback");
@@ -462,8 +462,7 @@ mod tests {
         });
         let resp = post_jsonrpc(app, methods::CREATE_PUSH_CONFIG, params).await;
         assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
-        let result =
-            protojson_conv::from_value::<TaskPushNotificationConfig>(resp.result.unwrap()).unwrap();
+        let result = serde_json::from_value::<TaskPushNotificationConfig>(resp.result.unwrap()).unwrap();
         assert_eq!(result.task_id, "t1");
         assert_eq!(result.config.id.as_deref(), Some("cfg1"));
         assert_eq!(result.config.url, "http://example.com/callback");
@@ -482,12 +481,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_push_configs() {
-        let app = make_app();
+        let app = make_push_app();
         let params = serde_json::json!({
             "taskId": "t1"
         });
         let resp = post_jsonrpc(app, methods::LIST_PUSH_CONFIGS, params).await;
-        assert!(resp.error.is_some() || resp.result.is_some());
+        assert!(resp.error.is_none(), "unexpected error: {:?}", resp.error);
+        let result = serde_json::from_value::<Vec<TaskPushNotificationConfig>>(resp.result.unwrap())
+            .unwrap();
+        assert!(result.is_empty());
     }
 
     #[tokio::test]

--- a/a2a-server/src/lib.rs
+++ b/a2a-server/src/lib.rs
@@ -5,6 +5,7 @@ pub mod executor;
 pub mod handler;
 pub mod jsonrpc;
 pub mod middleware;
+mod push_config_compat;
 pub mod push;
 pub mod rest;
 pub mod sse;

--- a/a2a-server/src/push_config_compat.rs
+++ b/a2a-server/src/push_config_compat.rs
@@ -1,0 +1,10 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use a2a::A2AError;
+use serde::Serialize;
+use serde_json::Value;
+
+pub(crate) fn json_value<T: Serialize>(value: &T) -> Result<Value, A2AError> {
+    serde_json::to_value(value)
+        .map_err(|e| A2AError::internal(format!("failed to serialize JSON payload: {e}")))
+}

--- a/a2a-server/src/rest.rs
+++ b/a2a-server/src/rest.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 
 use crate::handler::RequestHandler;
 use crate::middleware::ServiceParams;
+use crate::push_config_compat::json_value as compat_json_value;
 use crate::sse;
 
 const REST_SEND_MESSAGE_PATH: &str = "/message:send";
@@ -315,7 +316,7 @@ async fn handle_create_push_config<H: RequestHandler>(
     };
     let params = ServiceParams::new();
     match state.handler.create_push_config(&params, req).await {
-        Ok(resp) => protojson_json_response(&resp),
+        Ok(resp) => serde_json_response(&resp),
         Err(e) => rest_error_response(e),
     }
 }
@@ -331,7 +332,7 @@ async fn handle_get_push_config<H: RequestHandler>(
         tenant: None,
     };
     match state.handler.get_push_config(&params, req).await {
-        Ok(resp) => protojson_json_response(&resp),
+        Ok(resp) => serde_json_response(&resp),
         Err(e) => rest_error_response(e),
     }
 }
@@ -349,7 +350,7 @@ async fn handle_list_push_configs<H: RequestHandler>(
         tenant: None,
     };
     match state.handler.list_push_configs(&params, req).await {
-        Ok(resp) => protojson_json_response(&resp),
+        Ok(resp) => serde_json_response(&resp.configs),
         Err(e) => rest_error_response(e),
     }
 }
@@ -365,7 +366,7 @@ async fn handle_delete_push_config<H: RequestHandler>(
         tenant: None,
     };
     match state.handler.delete_push_config(&params, req).await {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => StatusCode::OK.into_response(),
         Err(e) => rest_error_response(e),
     }
 }
@@ -387,6 +388,13 @@ fn protojson_json_response<T: ProtoJsonPayload>(value: &T) -> axum::response::Re
         Err(e) => rest_error_response(A2AError::internal(format!(
             "failed to serialize ProtoJSON payload: {e}"
         ))),
+    }
+}
+
+fn serde_json_response<T: Serialize>(value: &T) -> axum::response::Response {
+    match compat_json_value(value) {
+        Ok(payload) => Json(payload).into_response(),
+        Err(e) => rest_error_response(e),
     }
 }
 
@@ -707,10 +715,7 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let payload = protojson_conv::from_str::<TaskPushNotificationConfig>(
-            std::str::from_utf8(&body).unwrap(),
-        )
-        .unwrap();
+        let payload = serde_json::from_slice::<TaskPushNotificationConfig>(&body).unwrap();
         assert_eq!(payload.task_id, "t1");
         assert_eq!(payload.config.id.as_deref(), Some("cfg1"));
         assert_eq!(payload.config.url, "http://example.com/callback");
@@ -735,10 +740,7 @@ mod tests {
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let body = resp.into_body().collect().await.unwrap().to_bytes();
-        let payload = protojson_conv::from_str::<TaskPushNotificationConfig>(
-            std::str::from_utf8(&body).unwrap(),
-        )
-        .unwrap();
+        let payload = serde_json::from_slice::<TaskPushNotificationConfig>(&body).unwrap();
         assert_eq!(payload.task_id, "t1");
         assert_eq!(payload.config.id.as_deref(), Some("cfg1"));
         assert_eq!(payload.config.url, "http://example.com/callback");
@@ -841,14 +843,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_push_configs() {
-        let app = make_app();
+        let app = make_push_app();
         let req = Request::builder()
             .uri("/tasks/t1/pushNotificationConfigs")
             .method("GET")
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
-        assert!(resp.status().is_client_error());
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let payload = serde_json::from_slice::<Vec<TaskPushNotificationConfig>>(&body).unwrap();
+        assert!(payload.is_empty());
     }
 
     #[tokio::test]
@@ -861,6 +866,42 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert!(resp.status().is_client_error());
+    }
+
+    #[tokio::test]
+    async fn test_delete_push_config_with_store_returns_ok() {
+        let app = make_push_app();
+        let create_body = serde_json::json!({
+            "id": "cfg1",
+            "url": "http://example.com/callback"
+        });
+        let create_req = Request::builder()
+            .uri("/tasks/t1/pushNotificationConfigs")
+            .method("POST")
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_string(&create_body).unwrap()))
+            .unwrap();
+        let create_resp = app.clone().oneshot(create_req).await.unwrap();
+        assert_eq!(create_resp.status(), StatusCode::OK);
+
+        let delete_req = Request::builder()
+            .uri("/tasks/t1/pushNotificationConfigs/cfg1")
+            .method("DELETE")
+            .body(Body::empty())
+            .unwrap();
+        let delete_resp = app.clone().oneshot(delete_req).await.unwrap();
+        assert_eq!(delete_resp.status(), StatusCode::OK);
+
+        let list_req = Request::builder()
+            .uri("/tasks/t1/pushNotificationConfigs")
+            .method("GET")
+            .body(Body::empty())
+            .unwrap();
+        let list_resp = app.oneshot(list_req).await.unwrap();
+        assert_eq!(list_resp.status(), StatusCode::OK);
+        let body = list_resp.into_body().collect().await.unwrap().to_bytes();
+        let payload = serde_json::from_slice::<Vec<TaskPushNotificationConfig>>(&body).unwrap();
+        assert!(payload.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- align JSON-RPC and REST push-config responses with the JSON shapes expected by a2a-go
- keep Rust JSON-RPC and REST clients backward-compatible with the older ProtoJSON push-config payloads during rollout
- return HTTP 200 for REST push-config deletes and cover the positive delete path in server tests

## Validation
- cargo fmt --all -- --check
- cargo test -p agntcy-a2a-server
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings