### PR TITLE
Add standalone a2acli CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "agntcy-a2acli"
+version = "0.1.0"
+dependencies = [
+ "agntcy-a2a",
+ "agntcy-a2a-client",
+ "agntcy-a2a-server",
+ "assert_cmd",
+ "async-trait",
+ "axum",
+ "clap",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "agntcy-slim"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +612,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +830,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -1116,6 +1161,12 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -2762,6 +2813,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,6 +3904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "textwrap"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4571,6 +4655,15 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "a2a-pb",
     "a2a-grpc",
     "a2a-slimrpc",
+    "a2acli",
     "examples/helloworld",
 ]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The workspace supports:
 | `a2a-pb` | Protobuf schema, generated types, ProtoJSON-capable generated types, and native <-> protobuf conversion helpers |
 | `a2a-grpc` | gRPC client and server bindings built on `tonic` |
 | `a2a-slimrpc` | SLIMRPC client and server bindings built on `slim_bindings` |
+| `a2acli` | Standalone A2A client CLI, published as `agntcy-a2acli`, for inspecting agent cards, sending messages, managing tasks, and handling push configs |
 | `examples/helloworld` | Minimal runnable example agent |
 
 ## Supported Bindings
@@ -101,6 +102,30 @@ When the example starts, the following endpoints are available:
 The example does not start a gRPC server, but the `a2a-grpc` crate provides the
 client and server bindings needed to add one.
 
+## Running The A2A CLI
+
+The workspace includes a standalone CLI client built on `a2a-client`. It
+resolves the public agent card from a base URL, negotiates JSON-RPC or
+HTTP+JSON, prints responses as JSON, and manages task push notification
+configs.
+
+```sh
+cargo run --bin a2acli -- card
+cargo run --bin a2acli -- send "hello from rust"
+cargo run --bin a2acli -- stream "hello from rust"
+cargo run --bin a2acli -- list-tasks
+cargo run --bin a2acli -- push-config list task-123
+```
+
+By default the CLI targets `http://localhost:3000`, which matches the bundled
+hello world server. Override the target with `--base-url https://host` for any
+compatible A2A server, use `--binding jsonrpc` or `--binding http-json` to pin
+transport selection, and pass `--bearer-token` or repeated `--header Name:Value`
+arguments when the server requires authentication.
+
+Install from the workspace with `cargo install --path a2acli`, or from crates.io
+after release with `cargo install agntcy-a2acli`.
+
 ## Depending On The Workspace
 
 Until the crates are published, depend on them directly from Git:
@@ -132,6 +157,7 @@ Typical usage is:
 - `a2a-pb/`: protobuf schema and conversion layer
 - `a2a-grpc/`: tonic-based bindings
 - `a2a-slimrpc/`: SLIMRPC bindings
+- `a2acli/`: standalone A2A client CLI and published binary package
 - `examples/helloworld/`: runnable sample agent
 
 ## Contributing

--- a/a2a-client/src/client.rs
+++ b/a2a-client/src/client.rs
@@ -1,5 +1,6 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
+use a2a::jsonrpc::methods;
 use a2a::*;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
@@ -35,83 +36,130 @@ impl A2AClient {
         self.default_params.clone()
     }
 
+    async fn apply_before(&self, method: &str) -> Result<ServiceParams, A2AError> {
+        let mut params = self.params();
+        for interceptor in &self.interceptors {
+            interceptor.before(method, &mut params).await?;
+        }
+        Ok(params)
+    }
+
+    async fn apply_after(
+        &self,
+        method: &str,
+        result: &Result<(), A2AError>,
+    ) -> Result<(), A2AError> {
+        for interceptor in self.interceptors.iter().rev() {
+            interceptor.after(method, result).await?;
+        }
+        Ok(())
+    }
+
+    async fn finish_call<T>(
+        &self,
+        method: &str,
+        result: Result<T, A2AError>,
+    ) -> Result<T, A2AError> {
+        let status = result.as_ref().map(|_| ()).map_err(Clone::clone);
+        let after_result = self.apply_after(method, &status).await;
+
+        match (result, after_result) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), _) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+        }
+    }
+
     pub async fn send_message(
         &self,
         req: &SendMessageRequest,
     ) -> Result<SendMessageResponse, A2AError> {
-        let params = self.params();
-        self.transport.send_message(&params, req).await
+        let params = self.apply_before(methods::SEND_MESSAGE).await?;
+        let result = self.transport.send_message(&params, req).await;
+        self.finish_call(methods::SEND_MESSAGE, result).await
     }
 
     pub async fn send_streaming_message(
         &self,
         req: &SendMessageRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
-        let params = self.params();
-        self.transport.send_streaming_message(&params, req).await
+        let params = self.apply_before(methods::SEND_STREAMING_MESSAGE).await?;
+        let result = self.transport.send_streaming_message(&params, req).await;
+        self.finish_call(methods::SEND_STREAMING_MESSAGE, result)
+            .await
     }
 
     pub async fn get_task(&self, req: &GetTaskRequest) -> Result<Task, A2AError> {
-        let params = self.params();
-        self.transport.get_task(&params, req).await
+        let params = self.apply_before(methods::GET_TASK).await?;
+        let result = self.transport.get_task(&params, req).await;
+        self.finish_call(methods::GET_TASK, result).await
     }
 
     pub async fn list_tasks(&self, req: &ListTasksRequest) -> Result<ListTasksResponse, A2AError> {
-        let params = self.params();
-        self.transport.list_tasks(&params, req).await
+        let params = self.apply_before(methods::LIST_TASKS).await?;
+        let result = self.transport.list_tasks(&params, req).await;
+        self.finish_call(methods::LIST_TASKS, result).await
     }
 
     pub async fn cancel_task(&self, req: &CancelTaskRequest) -> Result<Task, A2AError> {
-        let params = self.params();
-        self.transport.cancel_task(&params, req).await
+        let params = self.apply_before(methods::CANCEL_TASK).await?;
+        let result = self.transport.cancel_task(&params, req).await;
+        self.finish_call(methods::CANCEL_TASK, result).await
     }
 
     pub async fn subscribe_to_task(
         &self,
         req: &SubscribeToTaskRequest,
     ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
-        let params = self.params();
-        self.transport.subscribe_to_task(&params, req).await
+        let params = self.apply_before(methods::SUBSCRIBE_TO_TASK).await?;
+        let result = self.transport.subscribe_to_task(&params, req).await;
+        self.finish_call(methods::SUBSCRIBE_TO_TASK, result).await
     }
 
     pub async fn create_push_config(
         &self,
         req: &CreateTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        let params = self.params();
-        self.transport.create_push_config(&params, req).await
+        let params = self.apply_before(methods::CREATE_PUSH_CONFIG).await?;
+        let result = self.transport.create_push_config(&params, req).await;
+        self.finish_call(methods::CREATE_PUSH_CONFIG, result).await
     }
 
     pub async fn get_push_config(
         &self,
         req: &GetTaskPushNotificationConfigRequest,
     ) -> Result<TaskPushNotificationConfig, A2AError> {
-        let params = self.params();
-        self.transport.get_push_config(&params, req).await
+        let params = self.apply_before(methods::GET_PUSH_CONFIG).await?;
+        let result = self.transport.get_push_config(&params, req).await;
+        self.finish_call(methods::GET_PUSH_CONFIG, result).await
     }
 
     pub async fn list_push_configs(
         &self,
         req: &ListTaskPushNotificationConfigsRequest,
     ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
-        let params = self.params();
-        self.transport.list_push_configs(&params, req).await
+        let params = self.apply_before(methods::LIST_PUSH_CONFIGS).await?;
+        let result = self.transport.list_push_configs(&params, req).await;
+        self.finish_call(methods::LIST_PUSH_CONFIGS, result).await
     }
 
     pub async fn delete_push_config(
         &self,
         req: &DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
-        let params = self.params();
-        self.transport.delete_push_config(&params, req).await
+        let params = self.apply_before(methods::DELETE_PUSH_CONFIG).await?;
+        let result = self.transport.delete_push_config(&params, req).await;
+        self.finish_call(methods::DELETE_PUSH_CONFIG, result).await
     }
 
     pub async fn get_extended_agent_card(
         &self,
         req: &GetExtendedAgentCardRequest,
     ) -> Result<AgentCard, A2AError> {
-        let params = self.params();
-        self.transport.get_extended_agent_card(&params, req).await
+        let params = self.apply_before(methods::GET_EXTENDED_AGENT_CARD).await?;
+        let result = self.transport.get_extended_agent_card(&params, req).await;
+        self.finish_call(methods::GET_EXTENDED_AGENT_CARD, result)
+            .await
     }
 
     pub async fn destroy(&self) -> Result<(), A2AError> {
@@ -150,17 +198,50 @@ mod tests {
     use super::*;
     use a2a::event::StreamResponse;
     use futures::stream;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MockTransportState {
+        calls: Mutex<Vec<(String, ServiceParams)>>,
+        send_message_error: Mutex<Option<A2AError>>,
+    }
 
     /// Mock transport that returns canned responses.
-    struct MockTransport;
+    struct MockTransport {
+        state: Arc<MockTransportState>,
+    }
+
+    impl MockTransport {
+        fn new() -> (Self, Arc<MockTransportState>) {
+            let state = Arc::new(MockTransportState::default());
+            (
+                MockTransport {
+                    state: state.clone(),
+                },
+                state,
+            )
+        }
+
+        fn record(&self, method: &str, params: &ServiceParams) {
+            self.state
+                .calls
+                .lock()
+                .unwrap()
+                .push((method.to_string(), params.clone()));
+        }
+    }
 
     #[async_trait]
     impl Transport for MockTransport {
         async fn send_message(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             _req: &SendMessageRequest,
         ) -> Result<SendMessageResponse, A2AError> {
+            self.record(methods::SEND_MESSAGE, params);
+            if let Some(error) = self.state.send_message_error.lock().unwrap().clone() {
+                return Err(error);
+            }
             Ok(SendMessageResponse::Task(Task {
                 id: "t1".into(),
                 context_id: "c1".into(),
@@ -177,9 +258,10 @@ mod tests {
 
         async fn send_streaming_message(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             _req: &SendMessageRequest,
         ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            self.record(methods::SEND_STREAMING_MESSAGE, params);
             Ok(Box::pin(stream::once(async {
                 Ok(StreamResponse::StatusUpdate(
                     a2a::event::TaskStatusUpdateEvent {
@@ -198,9 +280,10 @@ mod tests {
 
         async fn get_task(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             req: &GetTaskRequest,
         ) -> Result<Task, A2AError> {
+            self.record(methods::GET_TASK, params);
             Ok(Task {
                 id: req.id.clone(),
                 context_id: "c1".into(),
@@ -217,9 +300,10 @@ mod tests {
 
         async fn list_tasks(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             _req: &ListTasksRequest,
         ) -> Result<ListTasksResponse, A2AError> {
+            self.record(methods::LIST_TASKS, params);
             Ok(ListTasksResponse {
                 tasks: vec![],
                 next_page_token: String::new(),
@@ -230,9 +314,10 @@ mod tests {
 
         async fn cancel_task(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             req: &CancelTaskRequest,
         ) -> Result<Task, A2AError> {
+            self.record(methods::CANCEL_TASK, params);
             Ok(Task {
                 id: req.id.clone(),
                 context_id: "c1".into(),
@@ -249,17 +334,19 @@ mod tests {
 
         async fn subscribe_to_task(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             _req: &SubscribeToTaskRequest,
         ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            self.record(methods::SUBSCRIBE_TO_TASK, params);
             Ok(Box::pin(stream::empty()))
         }
 
         async fn create_push_config(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             req: &CreateTaskPushNotificationConfigRequest,
         ) -> Result<TaskPushNotificationConfig, A2AError> {
+            self.record(methods::CREATE_PUSH_CONFIG, params);
             Ok(TaskPushNotificationConfig {
                 task_id: req.task_id.clone(),
                 config: req.config.clone(),
@@ -269,9 +356,10 @@ mod tests {
 
         async fn get_push_config(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             req: &GetTaskPushNotificationConfigRequest,
         ) -> Result<TaskPushNotificationConfig, A2AError> {
+            self.record(methods::GET_PUSH_CONFIG, params);
             Ok(TaskPushNotificationConfig {
                 task_id: req.task_id.clone(),
                 config: PushNotificationConfig {
@@ -286,9 +374,10 @@ mod tests {
 
         async fn list_push_configs(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             _req: &ListTaskPushNotificationConfigsRequest,
         ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+            self.record(methods::LIST_PUSH_CONFIGS, params);
             Ok(ListTaskPushNotificationConfigsResponse {
                 configs: vec![],
                 next_page_token: None,
@@ -297,17 +386,19 @@ mod tests {
 
         async fn delete_push_config(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             _req: &DeleteTaskPushNotificationConfigRequest,
         ) -> Result<(), A2AError> {
+            self.record(methods::DELETE_PUSH_CONFIG, params);
             Ok(())
         }
 
         async fn get_extended_agent_card(
             &self,
-            _params: &ServiceParams,
+            params: &ServiceParams,
             _req: &GetExtendedAgentCardRequest,
         ) -> Result<AgentCard, A2AError> {
+            self.record(methods::GET_EXTENDED_AGENT_CARD, params);
             Ok(AgentCard {
                 name: "Test".into(),
                 description: "Test agent".into(),
@@ -332,7 +423,41 @@ mod tests {
     }
 
     fn make_client() -> A2AClient {
-        A2AClient::new(Box::new(MockTransport))
+        let (transport, _) = MockTransport::new();
+        A2AClient::new(Box::new(transport))
+    }
+
+    struct RecordingInterceptor {
+        name: &'static str,
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl CallInterceptor for RecordingInterceptor {
+        async fn before(&self, _method: &str, params: &mut ServiceParams) -> Result<(), A2AError> {
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("before:{}", self.name));
+            params
+                .entry("X-Interceptor".to_string())
+                .or_default()
+                .push(self.name.to_string());
+            Ok(())
+        }
+
+        async fn after(
+            &self,
+            _method: &str,
+            result: &Result<(), A2AError>,
+        ) -> Result<(), A2AError> {
+            let status = if result.is_ok() { "ok" } else { "err" };
+            self.events
+                .lock()
+                .unwrap()
+                .push(format!("after:{}:{status}", self.name));
+            Ok(())
+        }
     }
 
     #[test]
@@ -359,6 +484,78 @@ mod tests {
         };
         let resp = client.send_message(&req).await.unwrap();
         assert!(matches!(resp, SendMessageResponse::Task(_)));
+    }
+
+    #[tokio::test]
+    async fn test_send_message_applies_interceptors_and_reverses_after_order() {
+        let (transport, state) = MockTransport::new();
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let client = A2AClient::new(Box::new(transport)).with_interceptors(vec![
+            Arc::new(RecordingInterceptor {
+                name: "first",
+                events: events.clone(),
+            }),
+            Arc::new(RecordingInterceptor {
+                name: "second",
+                events: events.clone(),
+            }),
+        ]);
+
+        let req = SendMessageRequest {
+            message: Message::new(Role::User, vec![Part::text("hi")]),
+            configuration: None,
+            metadata: None,
+            tenant: None,
+        };
+
+        client.send_message(&req).await.unwrap();
+
+        let calls = state.calls.lock().unwrap();
+        let params = &calls[0].1;
+        assert_eq!(
+            params.get("X-Interceptor").unwrap(),
+            &vec!["first".to_string(), "second".to_string()]
+        );
+
+        let events = events.lock().unwrap().clone();
+        assert_eq!(
+            events,
+            vec![
+                "before:first".to_string(),
+                "before:second".to_string(),
+                "after:second:ok".to_string(),
+                "after:first:ok".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_send_message_preserves_transport_error_after_after_hooks() {
+        let (transport, state) = MockTransport::new();
+        *state.send_message_error.lock().unwrap() = Some(A2AError::internal("boom"));
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let client = A2AClient::new(Box::new(transport)).with_interceptors(vec![Arc::new(
+            RecordingInterceptor {
+                name: "only",
+                events: events.clone(),
+            },
+        )]);
+
+        let req = SendMessageRequest {
+            message: Message::new(Role::User, vec![Part::text("hi")]),
+            configuration: None,
+            metadata: None,
+            tenant: None,
+        };
+
+        let err = client.send_message(&req).await.unwrap_err();
+        assert_eq!(err.message, "boom");
+
+        let events = events.lock().unwrap().clone();
+        assert_eq!(
+            events,
+            vec!["before:only".to_string(), "after:only:err".to_string(),]
+        );
     }
 
     #[tokio::test]

--- a/a2a/src/agent_card.rs
+++ b/a2a/src/agent_card.rs
@@ -36,7 +36,11 @@ pub struct AgentCard {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_schemes: Option<HashMap<String, SecurityScheme>>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_security_requirements"
+    )]
     pub security_requirements: Option<Vec<SecurityRequirement>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -49,6 +53,78 @@ where
     T: Deserialize<'de>,
 {
     Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+fn deserialize_optional_security_requirements<'de, D>(
+    deserializer: D,
+) -> Result<Option<Vec<SecurityRequirement>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = Option::<Vec<Value>>::deserialize(deserializer)?;
+
+    raw.map(|items| {
+        items
+            .into_iter()
+            .map(parse_security_requirement_value)
+            .collect()
+    })
+    .transpose()
+}
+
+fn parse_security_requirement_value<E>(value: Value) -> Result<SecurityRequirement, E>
+where
+    E: serde::de::Error,
+{
+    if let Ok(requirement) = serde_json::from_value::<SecurityRequirement>(value.clone()) {
+        return Ok(requirement);
+    }
+
+    let Value::Object(mut object) = value else {
+        return Err(E::custom("security requirement must be an object"));
+    };
+
+    if let Some(schemes) = object.remove("schemes") {
+        return parse_security_requirement_map::<E>(schemes);
+    }
+
+    Err(E::custom("invalid security requirement shape"))
+}
+
+fn parse_security_requirement_map<E>(value: Value) -> Result<SecurityRequirement, E>
+where
+    E: serde::de::Error,
+{
+    let Value::Object(object) = value else {
+        return Err(E::custom("security requirement schemes must be an object"));
+    };
+
+    let mut requirement = HashMap::new();
+    for (scheme, scopes_value) in object {
+        let scopes = match scopes_value {
+            Value::Array(_) => serde_json::from_value::<Vec<String>>(scopes_value)
+                .map_err(|e| E::custom(format!("invalid security scopes for {scheme}: {e}")))?,
+            Value::Object(mut wrapped) => {
+                let Some(list) = wrapped.remove("list") else {
+                    return Err(E::custom(format!(
+                        "invalid wrapped security scopes for {scheme}"
+                    )));
+                };
+                serde_json::from_value::<Vec<String>>(list).map_err(|e| {
+                    E::custom(format!("invalid wrapped security scopes for {scheme}: {e}"))
+                })?
+            }
+            _ => {
+                return Err(E::custom(format!(
+                    "security scopes for {scheme} must be a list"
+                )));
+            }
+        };
+
+        requirement.insert(scheme, scopes);
+    }
+
+    Ok(requirement)
 }
 
 // ---------------------------------------------------------------------------
@@ -204,7 +280,11 @@ pub struct AgentSkill {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub output_modes: Option<Vec<String>>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_optional_security_requirements"
+    )]
     pub security_requirements: Option<Vec<SecurityRequirement>>,
 }
 
@@ -764,5 +844,43 @@ mod tests {
         .unwrap();
 
         assert!(card.skills.is_empty());
+    }
+
+    #[test]
+    fn test_agent_card_deserializes_wrapped_security_requirements() {
+        let card: AgentCard = serde_json::from_str(
+            r#"{
+                "name": "Spec Agent",
+                "description": "A test agent",
+                "version": "1.0.0",
+                "supportedInterfaces": [
+                    {
+                        "url": "https://example.com/spec",
+                        "protocolBinding": "JSONRPC",
+                        "protocolVersion": "1.0"
+                    }
+                ],
+                "capabilities": {
+                    "streaming": true
+                },
+                "defaultInputModes": ["text/plain"],
+                "defaultOutputModes": ["text/plain"],
+                "skills": [],
+                "securityRequirements": [
+                    {
+                        "schemes": {
+                            "bearer_token": {
+                                "list": []
+                            }
+                        }
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let requirements = card.security_requirements.unwrap();
+        assert_eq!(requirements.len(), 1);
+        assert_eq!(requirements[0].get("bearer_token"), Some(&Vec::new()));
     }
 }

--- a/a2acli/CHANGELOG.md
+++ b/a2acli/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- add standalone `a2acli` binary crate
+- add task push notification config CRUD commands
+- make the package installable as `agntcy-a2acli`

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "agntcy-a2acli"
+version = "0.1.0"
+description = "Standalone A2A CLI client"
+readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lib]
+name = "a2acli"
+
+[[bin]]
+name = "a2acli"
+path = "src/main.rs"
+
+[dependencies]
+a2a = { workspace = true }
+a2a-client = { workspace = true }
+clap = { version = "4.5", features = ["derive", "env"] }
+futures = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+a2a-server = { workspace = true }
+assert_cmd = "2"
+async-trait = { workspace = true }
+axum = { workspace = true }

--- a/a2acli/README.md
+++ b/a2acli/README.md
@@ -1,0 +1,45 @@
+# a2acli
+
+Standalone A2A CLI client built on top of `a2a-client`.
+
+This crate is published as `agntcy-a2acli` and installs the `a2acli` binary.
+
+## Install
+
+From the workspace checkout:
+
+```sh
+cargo install --path a2acli
+```
+
+From crates.io after release:
+
+```sh
+cargo install agntcy-a2acli
+```
+
+## What It Provides
+
+- Fetch and print the public agent card for an A2A deployment
+- Send one-shot or streaming messages
+- Inspect, list, cancel, and subscribe to tasks
+- Create, fetch, list, and delete task push notification configs
+- Request an extended agent card when the server exposes one
+- Add bearer-token or custom-header authentication to all requests
+
+## Run
+
+```sh
+cargo run --bin a2acli -- card
+cargo run --bin a2acli -- send "hello from rust"
+cargo run --bin a2acli -- stream "hello from rust"
+cargo run --bin a2acli -- get-task task-123
+cargo run --bin a2acli -- push-config list task-123
+cargo run --bin a2acli -- push-config create task-123 https://example.com/callback --auth-scheme Bearer --auth-credentials secret
+```
+
+By default the CLI targets `http://localhost:3000`. Use `--base-url` to point at
+another deployment and `--binding jsonrpc` or `--binding http-json` to pin the
+transport when the agent card exposes more than one compatible interface. The
+global `--tenant`, `--bearer-token`, and repeated `--header Name:Value` options
+also apply to push-config commands.

--- a/a2acli/src/lib.rs
+++ b/a2acli/src/lib.rs
@@ -1,0 +1,1755 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use std::sync::Arc;
+
+use a2a::*;
+use a2a_client::auth::AuthInterceptor;
+use a2a_client::{A2AClient, A2AClientFactory, BoxStream};
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use futures::StreamExt;
+use reqwest::{Client, RequestBuilder};
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Parser, PartialEq, Eq)]
+#[command(name = "a2acli", version, about = "Standalone A2A client CLI")]
+pub struct Cli {
+    /// Base URL used to resolve /.well-known/agent-card.json.
+    #[arg(long, global = true, default_value = "http://localhost:3000")]
+    pub base_url: String,
+
+    /// Prefer a specific transport when the agent card exposes multiple bindings.
+    #[arg(long, global = true, value_enum)]
+    pub binding: Option<Binding>,
+
+    /// Bearer token attached to the agent-card fetch and client calls.
+    #[arg(long, global = true, env = "A2A_BEARER_TOKEN")]
+    pub bearer_token: Option<String>,
+
+    /// Extra HTTP header attached to the agent-card fetch and client calls.
+    #[arg(long = "header", global = true, value_parser = parse_header)]
+    pub headers: Vec<HeaderArg>,
+
+    /// Optional tenant forwarded to A2A requests that support it.
+    #[arg(long, global = true)]
+    pub tenant: Option<String>,
+
+    /// Emit compact JSON instead of pretty-printed JSON.
+    #[arg(long, global = true)]
+    pub compact: bool,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Debug, Clone, Subcommand, PartialEq, Eq)]
+pub enum Command {
+    /// Fetch and print the public agent card.
+    Card,
+    /// Fetch and print the extended agent card.
+    ExtendedCard,
+    /// Send a one-shot message.
+    Send(MessageCommand),
+    /// Send a streaming message and print each event as it arrives.
+    Stream(MessageCommand),
+    /// Fetch a task by ID.
+    GetTask(TaskLookupCommand),
+    /// List tasks with optional filters.
+    ListTasks(ListTasksCommand),
+    /// Cancel a task by ID.
+    CancelTask(TaskIdCommand),
+    /// Subscribe to task updates and print each event as it arrives.
+    Subscribe(TaskIdCommand),
+    /// Manage push notification configs for a task.
+    PushConfig {
+        #[command(subcommand)]
+        command: PushConfigCommand,
+    },
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct MessageCommand {
+    /// Text payload to send as the user message.
+    pub text: String,
+
+    /// Optional context identifier to continue an existing conversation.
+    #[arg(long)]
+    pub context_id: Option<String>,
+
+    /// Optional task identifier to continue an existing task.
+    #[arg(long)]
+    pub task_id: Option<String>,
+
+    /// Ask the server to include up to this many history items in task responses.
+    #[arg(long)]
+    pub history_length: Option<i32>,
+
+    /// Accepted output mode, for example text/plain or application/json.
+    #[arg(long = "accept-output")]
+    pub accepted_output_modes: Vec<String>,
+
+    /// Ask the server to return immediately when it supports queued work.
+    #[arg(long)]
+    pub return_immediately: bool,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct TaskLookupCommand {
+    /// Task identifier.
+    pub id: String,
+
+    /// Ask the server to include up to this many history items.
+    #[arg(long)]
+    pub history_length: Option<i32>,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct ListTasksCommand {
+    /// Filter by context identifier.
+    #[arg(long)]
+    pub context_id: Option<String>,
+
+    /// Filter by task state.
+    #[arg(long, value_enum)]
+    pub status: Option<TaskStateArg>,
+
+    /// Requested page size.
+    #[arg(long)]
+    pub page_size: Option<i32>,
+
+    /// Page token from a previous response.
+    #[arg(long)]
+    pub page_token: Option<String>,
+
+    /// Ask the server to include up to this many history items per task.
+    #[arg(long)]
+    pub history_length: Option<i32>,
+
+    /// Ask the server to include artifacts in the listed tasks.
+    #[arg(long)]
+    pub include_artifacts: bool,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct TaskIdCommand {
+    /// Task identifier.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Subcommand, PartialEq, Eq)]
+pub enum PushConfigCommand {
+    /// Create a push notification config for a task.
+    Create(CreatePushConfigCommand),
+    /// Fetch a push notification config by ID.
+    Get(PushConfigIdCommand),
+    /// List push notification configs for a task.
+    List(ListPushConfigsCommand),
+    /// Delete a push notification config by ID.
+    Delete(PushConfigIdCommand),
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct CreatePushConfigCommand {
+    /// Task identifier.
+    pub task_id: String,
+
+    /// Callback URL that will receive push notifications.
+    pub url: String,
+
+    /// Optional push config identifier.
+    #[arg(long = "config-id")]
+    pub config_id: Option<String>,
+
+    /// Optional push notification token.
+    #[arg(long)]
+    pub token: Option<String>,
+
+    /// Optional authentication scheme, for example Bearer.
+    #[arg(long = "auth-scheme")]
+    pub auth_scheme: Option<String>,
+
+    /// Optional authentication credentials.
+    #[arg(long = "auth-credentials")]
+    pub auth_credentials: Option<String>,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct PushConfigIdCommand {
+    /// Task identifier.
+    pub task_id: String,
+
+    /// Push config identifier.
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Args, PartialEq, Eq)]
+pub struct ListPushConfigsCommand {
+    /// Task identifier.
+    pub task_id: String,
+
+    /// Requested page size.
+    #[arg(long)]
+    pub page_size: Option<i32>,
+
+    /// Page token from a previous response.
+    #[arg(long)]
+    pub page_token: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeaderArg {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum Binding {
+    Jsonrpc,
+    HttpJson,
+}
+
+impl Binding {
+    fn protocol(self) -> &'static str {
+        match self {
+            Binding::Jsonrpc => TRANSPORT_PROTOCOL_JSONRPC,
+            Binding::HttpJson => TRANSPORT_PROTOCOL_HTTP_JSON,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum TaskStateArg {
+    Unspecified,
+    Submitted,
+    Working,
+    Completed,
+    Failed,
+    Canceled,
+    InputRequired,
+    Rejected,
+    AuthRequired,
+}
+
+impl From<TaskStateArg> for TaskState {
+    fn from(value: TaskStateArg) -> Self {
+        match value {
+            TaskStateArg::Unspecified => TaskState::Unspecified,
+            TaskStateArg::Submitted => TaskState::Submitted,
+            TaskStateArg::Working => TaskState::Working,
+            TaskStateArg::Completed => TaskState::Completed,
+            TaskStateArg::Failed => TaskState::Failed,
+            TaskStateArg::Canceled => TaskState::Canceled,
+            TaskStateArg::InputRequired => TaskState::InputRequired,
+            TaskStateArg::Rejected => TaskState::Rejected,
+            TaskStateArg::AuthRequired => TaskState::AuthRequired,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error(transparent)]
+    A2A(#[from] A2AError),
+    #[error("http request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("failed to serialize output: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
+}
+
+pub async fn run(cli: Cli) -> Result<(), CliError> {
+    match &cli.command {
+        Command::Card => {
+            let card = resolve_agent_card(&cli).await?;
+            print_json(&card, cli.compact)?;
+        }
+        Command::ExtendedCard => {
+            let client = resolve_client(&cli).await?;
+            let result = client
+                .get_extended_agent_card(&GetExtendedAgentCardRequest {
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let card = finish_client_call(client, result).await?;
+            print_json(&card, cli.compact)?;
+        }
+        Command::Send(command) => {
+            let request = build_send_message_request(command, cli.tenant.clone());
+            let client = resolve_client(&cli).await?;
+            let result = client.send_message(&request).await;
+            let response = finish_client_call(client, result).await?;
+            print_json(&response, cli.compact)?;
+        }
+        Command::Stream(command) => {
+            let client = resolve_client(&cli).await?;
+            let request = build_send_message_request(command, cli.tenant.clone());
+            let stream = client.send_streaming_message(&request).await?;
+            consume_stream(client, stream, cli.compact).await?;
+        }
+        Command::GetTask(command) => {
+            let client = resolve_client(&cli).await?;
+            let result = client
+                .get_task(&GetTaskRequest {
+                    id: command.id.clone(),
+                    history_length: command.history_length,
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let task = finish_client_call(client, result).await?;
+            print_json(&task, cli.compact)?;
+        }
+        Command::ListTasks(command) => {
+            let client = resolve_client(&cli).await?;
+            let result = client
+                .list_tasks(&ListTasksRequest {
+                    context_id: command.context_id.clone(),
+                    status: command.status.map(TaskState::from),
+                    page_size: command.page_size,
+                    page_token: command.page_token.clone(),
+                    history_length: command.history_length,
+                    status_timestamp_after: None,
+                    include_artifacts: command.include_artifacts.then_some(true),
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let response = finish_client_call(client, result).await?;
+            print_json(&response, cli.compact)?;
+        }
+        Command::CancelTask(command) => {
+            let client = resolve_client(&cli).await?;
+            let result = client
+                .cancel_task(&CancelTaskRequest {
+                    id: command.id.clone(),
+                    metadata: None,
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let task = finish_client_call(client, result).await?;
+            print_json(&task, cli.compact)?;
+        }
+        Command::Subscribe(command) => {
+            let client = resolve_client(&cli).await?;
+            let stream = client
+                .subscribe_to_task(&SubscribeToTaskRequest {
+                    id: command.id.clone(),
+                    tenant: cli.tenant.clone(),
+                })
+                .await?;
+            consume_stream(client, stream, cli.compact).await?;
+        }
+        Command::PushConfig { command } => {
+            run_push_config_command(&cli, command).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn build_send_message_request(
+    command: &MessageCommand,
+    tenant: Option<String>,
+) -> SendMessageRequest {
+    let mut message = Message::new(Role::User, vec![Part::text(command.text.clone())]);
+    message.context_id = command.context_id.clone();
+    message.task_id = command.task_id.clone();
+
+    let configuration = if command.history_length.is_some()
+        || !command.accepted_output_modes.is_empty()
+        || command.return_immediately
+    {
+        Some(SendMessageConfiguration {
+            accepted_output_modes: (!command.accepted_output_modes.is_empty())
+                .then_some(command.accepted_output_modes.clone()),
+            push_notification_config: None,
+            history_length: command.history_length,
+            return_immediately: command.return_immediately.then_some(true),
+        })
+    } else {
+        None
+    };
+
+    SendMessageRequest {
+        message,
+        configuration,
+        metadata: None,
+        tenant,
+    }
+}
+
+fn build_push_notification_config(
+    command: &CreatePushConfigCommand,
+) -> Result<PushNotificationConfig, CliError> {
+    if command.auth_credentials.is_some() && command.auth_scheme.is_none() {
+        return Err(CliError::InvalidInput(
+            "--auth-credentials requires --auth-scheme".to_string(),
+        ));
+    }
+
+    let authentication = command
+        .auth_scheme
+        .clone()
+        .map(|scheme| AuthenticationInfo {
+            scheme,
+            credentials: command.auth_credentials.clone(),
+        });
+
+    Ok(PushNotificationConfig {
+        url: command.url.clone(),
+        id: command.config_id.clone(),
+        token: command.token.clone(),
+        authentication,
+    })
+}
+
+async fn run_push_config_command(cli: &Cli, command: &PushConfigCommand) -> Result<(), CliError> {
+    match command {
+        PushConfigCommand::Create(command) => {
+            let client = resolve_client(cli).await?;
+            let config = build_push_notification_config(command)?;
+            let result = client
+                .create_push_config(&CreateTaskPushNotificationConfigRequest {
+                    task_id: command.task_id.clone(),
+                    config,
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let response = finish_client_call(client, result).await?;
+            print_json(&response, cli.compact)?;
+        }
+        PushConfigCommand::Get(command) => {
+            let client = resolve_client(cli).await?;
+            let result = client
+                .get_push_config(&GetTaskPushNotificationConfigRequest {
+                    task_id: command.task_id.clone(),
+                    id: command.id.clone(),
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let response = finish_client_call(client, result).await?;
+            print_json(&response, cli.compact)?;
+        }
+        PushConfigCommand::List(command) => {
+            let client = resolve_client(cli).await?;
+            let result = client
+                .list_push_configs(&ListTaskPushNotificationConfigsRequest {
+                    task_id: command.task_id.clone(),
+                    page_size: command.page_size,
+                    page_token: command.page_token.clone(),
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            let response = finish_client_call(client, result).await?;
+            print_json(&response, cli.compact)?;
+        }
+        PushConfigCommand::Delete(command) => {
+            let client = resolve_client(cli).await?;
+            let result = client
+                .delete_push_config(&DeleteTaskPushNotificationConfigRequest {
+                    task_id: command.task_id.clone(),
+                    id: command.id.clone(),
+                    tenant: cli.tenant.clone(),
+                })
+                .await;
+            finish_client_call(client, result).await?;
+            print_json(
+                &serde_json::json!({
+                    "deleted": true,
+                    "taskId": command.task_id,
+                    "id": command.id,
+                }),
+                cli.compact,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn resolve_client(cli: &Cli) -> Result<A2AClient, CliError> {
+    let card = resolve_agent_card(cli).await?;
+
+    let mut builder = A2AClientFactory::builder();
+    if let Some(binding) = cli.binding {
+        builder = builder.preferred_bindings(vec![binding.protocol().to_string()]);
+    }
+    if let Some(token) = &cli.bearer_token {
+        builder = builder.with_interceptor(Arc::new(AuthInterceptor::bearer(token.clone())));
+    }
+    for header in &cli.headers {
+        builder = builder.with_interceptor(Arc::new(AuthInterceptor::custom(
+            header.name.clone(),
+            header.value.clone(),
+        )));
+    }
+
+    let factory = builder.build();
+    Ok(factory.create_from_card(&card).await?)
+}
+
+async fn resolve_agent_card(cli: &Cli) -> Result<AgentCard, CliError> {
+    let url = format!(
+        "{}/.well-known/agent-card.json",
+        cli.base_url.trim_end_matches('/')
+    );
+    let client = Client::new();
+    let request = apply_request_auth(client.get(url), cli);
+    let response = request.send().await?.error_for_status()?;
+    Ok(response.json::<AgentCard>().await?)
+}
+
+fn apply_request_auth(mut request: RequestBuilder, cli: &Cli) -> RequestBuilder {
+    if let Some(token) = &cli.bearer_token {
+        request = request.bearer_auth(token);
+    }
+    for header in &cli.headers {
+        request = request.header(&header.name, &header.value);
+    }
+    request
+}
+
+fn print_json<T: Serialize>(value: &T, compact: bool) -> Result<(), CliError> {
+    if compact {
+        println!("{}", serde_json::to_string(value)?);
+    } else {
+        println!("{}", serde_json::to_string_pretty(value)?);
+    }
+    Ok(())
+}
+
+fn parse_header(input: &str) -> Result<HeaderArg, String> {
+    let (name, value) = input
+        .split_once(':')
+        .ok_or_else(|| "header must be in NAME:VALUE format".to_string())?;
+
+    let name = name.trim();
+    let value = value.trim();
+
+    if name.is_empty() {
+        return Err("header name cannot be empty".to_string());
+    }
+
+    Ok(HeaderArg {
+        name: name.to_string(),
+        value: value.to_string(),
+    })
+}
+
+async fn finish_client_call<T>(
+    client: A2AClient,
+    result: Result<T, A2AError>,
+) -> Result<T, CliError> {
+    match result {
+        Ok(value) => {
+            client.destroy().await?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = client.destroy().await;
+            Err(error.into())
+        }
+    }
+}
+
+async fn consume_stream<T: Serialize>(
+    client: A2AClient,
+    mut stream: BoxStream<'static, Result<T, A2AError>>,
+    compact: bool,
+) -> Result<(), CliError> {
+    loop {
+        match stream.next().await {
+            Some(Ok(value)) => {
+                if let Err(error) = print_json(&value, compact) {
+                    let _ = client.destroy().await;
+                    return Err(error);
+                }
+            }
+            Some(Err(error)) => {
+                let _ = client.destroy().await;
+                return Err(error.into());
+            }
+            None => {
+                client.destroy().await?;
+                return Ok(());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a_client::{ServiceParams, Transport};
+    use a2a_server::jsonrpc::jsonrpc_router;
+    use a2a_server::rest::rest_router;
+    use a2a_server::{
+        RequestHandler, ServiceParams as HandlerServiceParams, WELL_KNOWN_AGENT_CARD_PATH,
+    };
+    use async_trait::async_trait;
+    use axum::routing::get;
+    use axum::{Json, Router};
+    use futures::stream;
+    use reqwest::header;
+    use serde::ser;
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+    use tokio::net::TcpListener;
+
+    struct TestTransport {
+        destroy_error: Option<A2AError>,
+    }
+
+    #[async_trait]
+    impl Transport for TestTransport {
+        async fn send_message(
+            &self,
+            _params: &ServiceParams,
+            _req: &SendMessageRequest,
+        ) -> Result<SendMessageResponse, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn send_streaming_message(
+            &self,
+            _params: &ServiceParams,
+            _req: &SendMessageRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn get_task(
+            &self,
+            _params: &ServiceParams,
+            _req: &GetTaskRequest,
+        ) -> Result<Task, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn list_tasks(
+            &self,
+            _params: &ServiceParams,
+            _req: &ListTasksRequest,
+        ) -> Result<ListTasksResponse, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn cancel_task(
+            &self,
+            _params: &ServiceParams,
+            _req: &CancelTaskRequest,
+        ) -> Result<Task, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn subscribe_to_task(
+            &self,
+            _params: &ServiceParams,
+            _req: &SubscribeToTaskRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn create_push_config(
+            &self,
+            _params: &ServiceParams,
+            _req: &CreateTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn get_push_config(
+            &self,
+            _params: &ServiceParams,
+            _req: &GetTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn list_push_configs(
+            &self,
+            _params: &ServiceParams,
+            _req: &ListTaskPushNotificationConfigsRequest,
+        ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn delete_push_config(
+            &self,
+            _params: &ServiceParams,
+            _req: &DeleteTaskPushNotificationConfigRequest,
+        ) -> Result<(), A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn get_extended_agent_card(
+            &self,
+            _params: &ServiceParams,
+            _req: &GetExtendedAgentCardRequest,
+        ) -> Result<AgentCard, A2AError> {
+            Err(A2AError::unsupported_operation("unused"))
+        }
+
+        async fn destroy(&self) -> Result<(), A2AError> {
+            match &self.destroy_error {
+                Some(error) => Err(error.clone()),
+                None => Ok(()),
+            }
+        }
+    }
+
+    struct FailingSerialize;
+
+    impl Serialize for FailingSerialize {
+        fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            Err(ser::Error::custom("serialize failed"))
+        }
+    }
+
+    fn make_test_client(destroy_error: Option<A2AError>) -> A2AClient {
+        A2AClient::new(Box::new(TestTransport { destroy_error }))
+    }
+
+    #[derive(Default)]
+    struct RunTestState {
+        tasks: Mutex<BTreeMap<String, Task>>,
+        push_configs: Mutex<BTreeMap<(String, String), TaskPushNotificationConfig>>,
+    }
+
+    struct RunTestHandler {
+        state: Arc<RunTestState>,
+        extended_card: AgentCard,
+    }
+
+    struct RunTestServer {
+        base_url: String,
+        handle: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for RunTestServer {
+        fn drop(&mut self) {
+            self.handle.abort();
+        }
+    }
+
+    impl RunTestServer {
+        async fn spawn() -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let base_url = format!("http://{}", listener.local_addr().unwrap());
+            let state = Arc::new(RunTestState::default());
+
+            state.tasks.lock().unwrap().insert(
+                "task-1".to_string(),
+                make_fixture_task("task-1", "ctx-1", TaskState::Completed, "seeded result"),
+            );
+
+            let public_card = make_fixture_card(&base_url, "Fixture Agent");
+            let extended_card = make_fixture_card(&base_url, "Fixture Agent (extended)");
+            let handler = Arc::new(RunTestHandler {
+                state,
+                extended_card,
+            });
+
+            let card = public_card.clone();
+            let app = Router::new()
+                .route(
+                    WELL_KNOWN_AGENT_CARD_PATH,
+                    get(move || {
+                        let card = card.clone();
+                        async move { Json(card) }
+                    }),
+                )
+                .nest("/jsonrpc", jsonrpc_router(handler.clone()))
+                .nest("/rest", rest_router(handler));
+
+            let handle = tokio::spawn(async move {
+                axum::serve(listener, app).await.unwrap();
+            });
+
+            RunTestServer { base_url, handle }
+        }
+    }
+
+    #[async_trait]
+    impl RequestHandler for RunTestHandler {
+        async fn send_message(
+            &self,
+            _params: &HandlerServiceParams,
+            req: SendMessageRequest,
+        ) -> Result<SendMessageResponse, A2AError> {
+            let task_id = req
+                .message
+                .task_id
+                .clone()
+                .unwrap_or_else(|| "task-send".to_string());
+            let context_id = req
+                .message
+                .context_id
+                .clone()
+                .unwrap_or_else(|| "ctx-send".to_string());
+            let text = req.message.text().unwrap_or_default();
+            if text == "send-error" {
+                return Err(A2AError::invalid_request("send failed"));
+            }
+
+            let task = make_fixture_task(
+                &task_id,
+                &context_id,
+                TaskState::Completed,
+                &format!("Echo: {text}"),
+            );
+            self.state
+                .tasks
+                .lock()
+                .unwrap()
+                .insert(task_id, task.clone());
+            Ok(SendMessageResponse::Task(task))
+        }
+
+        async fn send_streaming_message(
+            &self,
+            _params: &HandlerServiceParams,
+            req: SendMessageRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            let task_id = req
+                .message
+                .task_id
+                .clone()
+                .unwrap_or_else(|| "task-stream".to_string());
+            let context_id = req
+                .message
+                .context_id
+                .clone()
+                .unwrap_or_else(|| "ctx-stream".to_string());
+            let text = req.message.text().unwrap_or_default();
+            if text == "stream-error" {
+                return Ok(Box::pin(stream::once(async {
+                    Err(A2AError::internal("stream failed"))
+                })));
+            }
+
+            let task = make_fixture_task(
+                &task_id,
+                &context_id,
+                TaskState::Completed,
+                &format!("Echo: {text}"),
+            );
+            self.state
+                .tasks
+                .lock()
+                .unwrap()
+                .insert(task_id.clone(), task.clone());
+
+            Ok(Box::pin(stream::iter(vec![
+                Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                    task_id,
+                    context_id,
+                    status: TaskStatus {
+                        state: TaskState::Working,
+                        message: None,
+                        timestamp: None,
+                    },
+                    metadata: None,
+                })),
+                Ok(StreamResponse::Task(task)),
+            ])))
+        }
+
+        async fn get_task(
+            &self,
+            _params: &HandlerServiceParams,
+            req: GetTaskRequest,
+        ) -> Result<Task, A2AError> {
+            self.state
+                .tasks
+                .lock()
+                .unwrap()
+                .get(&req.id)
+                .cloned()
+                .ok_or_else(|| A2AError::task_not_found(&req.id))
+        }
+
+        async fn list_tasks(
+            &self,
+            _params: &HandlerServiceParams,
+            req: ListTasksRequest,
+        ) -> Result<ListTasksResponse, A2AError> {
+            if req.context_id.as_deref() == Some("error") {
+                return Err(A2AError::invalid_params("list failed"));
+            }
+
+            let tasks = self
+                .state
+                .tasks
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|task| {
+                    req.context_id
+                        .as_ref()
+                        .map(|context_id| task.context_id == *context_id)
+                        .unwrap_or(true)
+                })
+                .filter(|task| {
+                    req.status
+                        .as_ref()
+                        .map(|status| task.status.state == *status)
+                        .unwrap_or(true)
+                })
+                .cloned()
+                .collect();
+
+            Ok(ListTasksResponse {
+                tasks,
+                next_page_token: String::new(),
+                page_size: 0,
+                total_size: 0,
+            })
+        }
+
+        async fn cancel_task(
+            &self,
+            _params: &HandlerServiceParams,
+            req: CancelTaskRequest,
+        ) -> Result<Task, A2AError> {
+            let mut tasks = self.state.tasks.lock().unwrap();
+            let task = tasks
+                .get(&req.id)
+                .cloned()
+                .ok_or_else(|| A2AError::task_not_found(&req.id))?;
+            let canceled =
+                make_fixture_task(&task.id, &task.context_id, TaskState::Canceled, "canceled");
+            tasks.insert(req.id, canceled.clone());
+            Ok(canceled)
+        }
+
+        async fn subscribe_to_task(
+            &self,
+            _params: &HandlerServiceParams,
+            req: SubscribeToTaskRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            if req.id == "stream-error" {
+                return Ok(Box::pin(stream::once(async {
+                    Err(A2AError::internal("stream failed"))
+                })));
+            }
+
+            let task = self
+                .state
+                .tasks
+                .lock()
+                .unwrap()
+                .get(&req.id)
+                .cloned()
+                .ok_or_else(|| A2AError::task_not_found(&req.id))?;
+
+            Ok(Box::pin(stream::iter(vec![
+                Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                    task_id: req.id.clone(),
+                    context_id: task.context_id.clone(),
+                    status: TaskStatus {
+                        state: TaskState::Working,
+                        message: None,
+                        timestamp: None,
+                    },
+                    metadata: None,
+                })),
+                Ok(StreamResponse::Task(task)),
+            ])))
+        }
+
+        async fn create_push_config(
+            &self,
+            _params: &HandlerServiceParams,
+            req: CreateTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            if !self.state.tasks.lock().unwrap().contains_key(&req.task_id) {
+                return Err(A2AError::task_not_found(&req.task_id));
+            }
+
+            let config = TaskPushNotificationConfig {
+                task_id: req.task_id.clone(),
+                config: req.config,
+                tenant: req.tenant,
+            };
+            let config_id = config
+                .config
+                .id
+                .clone()
+                .unwrap_or_else(|| "generated".to_string());
+            self.state
+                .push_configs
+                .lock()
+                .unwrap()
+                .insert((req.task_id, config_id), config.clone());
+            Ok(config)
+        }
+
+        async fn get_push_config(
+            &self,
+            _params: &HandlerServiceParams,
+            req: GetTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            self.state
+                .push_configs
+                .lock()
+                .unwrap()
+                .get(&(req.task_id.clone(), req.id.clone()))
+                .cloned()
+                .ok_or_else(|| A2AError::task_not_found(&req.task_id))
+        }
+
+        async fn list_push_configs(
+            &self,
+            _params: &HandlerServiceParams,
+            req: ListTaskPushNotificationConfigsRequest,
+        ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+            if req.task_id == "missing" {
+                return Err(A2AError::task_not_found(&req.task_id));
+            }
+
+            let configs = self
+                .state
+                .push_configs
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|config| config.task_id == req.task_id)
+                .cloned()
+                .collect();
+
+            Ok(ListTaskPushNotificationConfigsResponse {
+                configs,
+                next_page_token: None,
+            })
+        }
+
+        async fn delete_push_config(
+            &self,
+            _params: &HandlerServiceParams,
+            req: DeleteTaskPushNotificationConfigRequest,
+        ) -> Result<(), A2AError> {
+            let deleted = self
+                .state
+                .push_configs
+                .lock()
+                .unwrap()
+                .remove(&(req.task_id.clone(), req.id.clone()));
+            if deleted.is_none() {
+                return Err(A2AError::task_not_found(&req.task_id));
+            }
+            Ok(())
+        }
+
+        async fn get_extended_agent_card(
+            &self,
+            _params: &HandlerServiceParams,
+            req: GetExtendedAgentCardRequest,
+        ) -> Result<AgentCard, A2AError> {
+            if req.tenant.as_deref() == Some("error") {
+                return Err(A2AError::unsupported_operation("extended card denied"));
+            }
+
+            Ok(self.extended_card.clone())
+        }
+    }
+
+    fn make_fixture_card(base_url: &str, name: &str) -> AgentCard {
+        AgentCard {
+            name: name.to_string(),
+            description: "CLI unit-test fixture".to_string(),
+            version: VERSION.to_string(),
+            supported_interfaces: vec![
+                AgentInterface::new(format!("{base_url}/jsonrpc"), TRANSPORT_PROTOCOL_JSONRPC),
+                AgentInterface::new(format!("{base_url}/rest"), TRANSPORT_PROTOCOL_HTTP_JSON),
+            ],
+            capabilities: AgentCapabilities {
+                streaming: Some(true),
+                push_notifications: Some(true),
+                extensions: None,
+                extended_agent_card: Some(true),
+            },
+            default_input_modes: vec!["text/plain".to_string()],
+            default_output_modes: vec!["text/plain".to_string()],
+            skills: vec![],
+            provider: None,
+            documentation_url: None,
+            icon_url: None,
+            security_schemes: None,
+            security_requirements: None,
+            signatures: None,
+        }
+    }
+
+    fn make_fixture_task(task_id: &str, context_id: &str, state: TaskState, text: &str) -> Task {
+        Task {
+            id: task_id.to_string(),
+            context_id: context_id.to_string(),
+            status: TaskStatus {
+                state,
+                message: Some(Message {
+                    message_id: format!("msg-{task_id}"),
+                    context_id: Some(context_id.to_string()),
+                    task_id: Some(task_id.to_string()),
+                    role: Role::Agent,
+                    parts: vec![Part::text(text)],
+                    metadata: None,
+                    extensions: None,
+                    reference_task_ids: None,
+                }),
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        }
+    }
+
+    fn parse_cli_with_base_url(base_url: &str, args: &[&str]) -> Cli {
+        let mut argv = vec![
+            "a2acli".to_string(),
+            "--base-url".to_string(),
+            base_url.to_string(),
+        ];
+        argv.extend(args.iter().map(|arg| (*arg).to_string()));
+        Cli::try_parse_from(argv).unwrap()
+    }
+
+    async fn unused_base_url() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        format!("http://{addr}")
+    }
+
+    fn assert_unsupported_operation<T>(result: Result<T, A2AError>) {
+        match result {
+            Ok(_) => panic!("expected unsupported operation error"),
+            Err(err) => assert_eq!(err.code, a2a::error_code::UNSUPPORTED_OPERATION),
+        }
+    }
+
+    #[test]
+    fn test_parse_header() {
+        let header = parse_header("Authorization: Bearer token").unwrap();
+        assert_eq!(header.name, "Authorization");
+        assert_eq!(header.value, "Bearer token");
+    }
+
+    #[test]
+    fn test_parse_header_requires_separator() {
+        let err = parse_header("Authorization").unwrap_err();
+        assert_eq!(err, "header must be in NAME:VALUE format");
+    }
+
+    #[test]
+    fn test_parse_header_requires_name() {
+        let err = parse_header(": value").unwrap_err();
+        assert_eq!(err, "header name cannot be empty");
+    }
+
+    #[test]
+    fn test_build_send_message_request_populates_optional_fields() {
+        let request = build_send_message_request(
+            &MessageCommand {
+                text: "hello".to_string(),
+                context_id: Some("ctx-1".to_string()),
+                task_id: Some("task-1".to_string()),
+                history_length: Some(4),
+                accepted_output_modes: vec!["text/plain".to_string()],
+                return_immediately: true,
+            },
+            Some("tenant-1".to_string()),
+        );
+
+        assert_eq!(request.message.text(), Some("hello"));
+        assert_eq!(request.message.context_id.as_deref(), Some("ctx-1"));
+        assert_eq!(request.message.task_id.as_deref(), Some("task-1"));
+        assert_eq!(request.tenant.as_deref(), Some("tenant-1"));
+        assert_eq!(
+            request
+                .configuration
+                .as_ref()
+                .and_then(|config| config.history_length),
+            Some(4)
+        );
+        assert_eq!(
+            request
+                .configuration
+                .as_ref()
+                .and_then(|config| config.return_immediately),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_build_send_message_request_without_optional_fields() {
+        let request = build_send_message_request(
+            &MessageCommand {
+                text: "hello".to_string(),
+                context_id: None,
+                task_id: None,
+                history_length: None,
+                accepted_output_modes: Vec::new(),
+                return_immediately: false,
+            },
+            None,
+        );
+
+        assert_eq!(request.message.text(), Some("hello"));
+        assert!(request.configuration.is_none());
+        assert!(request.tenant.is_none());
+    }
+
+    #[test]
+    fn test_cli_parse_send_command() {
+        let cli = Cli::try_parse_from([
+            "a2acli",
+            "--binding",
+            "jsonrpc",
+            "--header",
+            "X-Test:123",
+            "send",
+            "hello",
+            "--history-length",
+            "2",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.binding, Some(Binding::Jsonrpc));
+        assert_eq!(cli.headers.len(), 1);
+        assert!(matches!(cli.command, Command::Send(_)));
+    }
+
+    #[test]
+    fn test_cli_parse_push_config_create_command() {
+        let cli = Cli::try_parse_from([
+            "a2acli",
+            "push-config",
+            "create",
+            "task-1",
+            "https://example.com/callback",
+            "--config-id",
+            "cfg-1",
+            "--token",
+            "tok-1",
+            "--auth-scheme",
+            "Bearer",
+            "--auth-credentials",
+            "secret",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::PushConfig {
+                command: PushConfigCommand::Create(command),
+            } => {
+                assert_eq!(command.task_id, "task-1");
+                assert_eq!(command.url, "https://example.com/callback");
+                assert_eq!(command.config_id.as_deref(), Some("cfg-1"));
+                assert_eq!(command.token.as_deref(), Some("tok-1"));
+                assert_eq!(command.auth_scheme.as_deref(), Some("Bearer"));
+                assert_eq!(command.auth_credentials.as_deref(), Some("secret"));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_build_push_notification_config() {
+        let config = build_push_notification_config(&CreatePushConfigCommand {
+            task_id: "task-1".to_string(),
+            url: "https://example.com/callback".to_string(),
+            config_id: Some("cfg-1".to_string()),
+            token: Some("tok-1".to_string()),
+            auth_scheme: Some("Bearer".to_string()),
+            auth_credentials: Some("secret".to_string()),
+        })
+        .unwrap();
+
+        assert_eq!(config.id.as_deref(), Some("cfg-1"));
+        assert_eq!(config.token.as_deref(), Some("tok-1"));
+        assert_eq!(
+            config
+                .authentication
+                .as_ref()
+                .map(|auth| auth.scheme.as_str()),
+            Some("Bearer")
+        );
+        assert_eq!(
+            config
+                .authentication
+                .as_ref()
+                .and_then(|auth| auth.credentials.as_deref()),
+            Some("secret")
+        );
+    }
+
+    #[test]
+    fn test_build_push_notification_config_requires_auth_scheme() {
+        let err = build_push_notification_config(&CreatePushConfigCommand {
+            task_id: "task-1".to_string(),
+            url: "https://example.com/callback".to_string(),
+            config_id: None,
+            token: None,
+            auth_scheme: None,
+            auth_credentials: Some("secret".to_string()),
+        })
+        .unwrap_err();
+
+        assert!(matches!(err, CliError::InvalidInput(_)));
+    }
+
+    #[test]
+    fn test_build_push_notification_config_without_authentication() {
+        let config = build_push_notification_config(&CreatePushConfigCommand {
+            task_id: "task-1".to_string(),
+            url: "https://example.com/callback".to_string(),
+            config_id: None,
+            token: None,
+            auth_scheme: None,
+            auth_credentials: None,
+        })
+        .unwrap();
+
+        assert_eq!(config.url, "https://example.com/callback");
+        assert!(config.authentication.is_none());
+    }
+
+    #[test]
+    fn test_binding_protocols() {
+        assert_eq!(Binding::Jsonrpc.protocol(), TRANSPORT_PROTOCOL_JSONRPC);
+        assert_eq!(Binding::HttpJson.protocol(), TRANSPORT_PROTOCOL_HTTP_JSON);
+    }
+
+    #[test]
+    fn test_apply_request_auth_builds_headers() {
+        let cli = Cli::try_parse_from([
+            "a2acli",
+            "--bearer-token",
+            "secret",
+            "--header",
+            "X-Test: 123",
+            "card",
+        ])
+        .unwrap();
+
+        let request = apply_request_auth(Client::new().get("http://example.com"), &cli)
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.headers().get(header::AUTHORIZATION).unwrap(),
+            "Bearer secret"
+        );
+        assert_eq!(request.headers().get("X-Test").unwrap(), "123");
+    }
+
+    #[tokio::test]
+    async fn test_finish_client_call_propagates_destroy_error() {
+        let err = finish_client_call(
+            make_test_client(Some(A2AError::internal("destroy failed"))),
+            Ok(serde_json::json!({ "ok": true })),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, CliError::A2A(_)));
+    }
+
+    #[tokio::test]
+    async fn test_consume_stream_reports_json_error() {
+        let stream = Box::pin(stream::once(async { Ok(FailingSerialize) }));
+        let err = consume_stream(make_test_client(None), stream, false)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, CliError::Json(_)));
+    }
+
+    #[tokio::test]
+    async fn test_consume_stream_propagates_destroy_error_on_completion() {
+        let stream = Box::pin(stream::empty::<Result<serde_json::Value, A2AError>>());
+        let err = consume_stream(
+            make_test_client(Some(A2AError::internal("destroy failed"))),
+            stream,
+            true,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, CliError::A2A(_)));
+    }
+
+    #[tokio::test]
+    async fn test_test_transport_methods_return_unused_errors() {
+        let transport = TestTransport {
+            destroy_error: None,
+        };
+        let params = ServiceParams::new();
+
+        assert_unsupported_operation(
+            transport
+                .send_message(
+                    &params,
+                    &SendMessageRequest {
+                        message: Message::new(Role::User, vec![Part::text("hello")]),
+                        configuration: None,
+                        metadata: None,
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .send_streaming_message(
+                    &params,
+                    &SendMessageRequest {
+                        message: Message::new(Role::User, vec![Part::text("hello")]),
+                        configuration: None,
+                        metadata: None,
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .get_task(
+                    &params,
+                    &GetTaskRequest {
+                        id: "task-1".to_string(),
+                        history_length: None,
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .list_tasks(
+                    &params,
+                    &ListTasksRequest {
+                        context_id: None,
+                        status: None,
+                        page_size: None,
+                        page_token: None,
+                        history_length: None,
+                        status_timestamp_after: None,
+                        include_artifacts: None,
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .cancel_task(
+                    &params,
+                    &CancelTaskRequest {
+                        id: "task-1".to_string(),
+                        metadata: None,
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .subscribe_to_task(
+                    &params,
+                    &SubscribeToTaskRequest {
+                        id: "task-1".to_string(),
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .create_push_config(
+                    &params,
+                    &CreateTaskPushNotificationConfigRequest {
+                        task_id: "task-1".to_string(),
+                        config: PushNotificationConfig {
+                            url: "https://example.com/callback".to_string(),
+                            id: Some("cfg-1".to_string()),
+                            token: None,
+                            authentication: None,
+                        },
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .get_push_config(
+                    &params,
+                    &GetTaskPushNotificationConfigRequest {
+                        task_id: "task-1".to_string(),
+                        id: "cfg-1".to_string(),
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .list_push_configs(
+                    &params,
+                    &ListTaskPushNotificationConfigsRequest {
+                        task_id: "task-1".to_string(),
+                        page_size: None,
+                        page_token: None,
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .delete_push_config(
+                    &params,
+                    &DeleteTaskPushNotificationConfigRequest {
+                        task_id: "task-1".to_string(),
+                        id: "cfg-1".to_string(),
+                        tenant: None,
+                    },
+                )
+                .await,
+        );
+        assert_unsupported_operation(
+            transport
+                .get_extended_agent_card(&params, &GetExtendedAgentCardRequest { tenant: None })
+                .await,
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_run_executes_all_commands_in_lib_tests() {
+        let server = RunTestServer::spawn().await;
+
+        run(parse_cli_with_base_url(&server.base_url, &["card"]))
+            .await
+            .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &["--compact", "extended-card"],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &[
+                "--binding",
+                "jsonrpc",
+                "--bearer-token",
+                "secret",
+                "--header",
+                "X-Test: 123",
+                "send",
+                "hello from unit test",
+                "--task-id",
+                "task-send",
+                "--context-id",
+                "ctx-send",
+            ],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &[
+                "--compact",
+                "stream",
+                "streaming request",
+                "--task-id",
+                "task-stream",
+                "--context-id",
+                "ctx-stream",
+            ],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &["get-task", "task-send"],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &[
+                "--compact",
+                "list-tasks",
+                "--context-id",
+                "ctx-send",
+                "--status",
+                "completed",
+            ],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &["cancel-task", "task-send"],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &["--compact", "subscribe", "task-stream"],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &[
+                "push-config",
+                "create",
+                "task-1",
+                "https://example.com/callback",
+                "--config-id",
+                "cfg-1",
+            ],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &["--compact", "push-config", "get", "task-1", "cfg-1"],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &["--compact", "push-config", "list", "task-1"],
+        ))
+        .await
+        .unwrap();
+        run(parse_cli_with_base_url(
+            &server.base_url,
+            &["push-config", "delete", "task-1", "cfg-1"],
+        ))
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_run_surfaces_errors_in_lib_tests() {
+        let server = RunTestServer::spawn().await;
+
+        let err = run(parse_cli_with_base_url(
+            &server.base_url,
+            &["extended-card", "--tenant", "error"],
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::UNSUPPORTED_OPERATION
+        ));
+
+        let err = run(parse_cli_with_base_url(
+            &server.base_url,
+            &["send", "send-error"],
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::INVALID_REQUEST
+        ));
+
+        let err = run(parse_cli_with_base_url(
+            &server.base_url,
+            &["list-tasks", "--context-id", "error"],
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::INVALID_PARAMS
+        ));
+
+        let err = run(parse_cli_with_base_url(
+            &server.base_url,
+            &["--compact", "stream", "stream-error"],
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
+        ));
+
+        let err = run(parse_cli_with_base_url(
+            &server.base_url,
+            &["--compact", "subscribe", "stream-error"],
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::INTERNAL_ERROR
+        ));
+
+        let err = run(parse_cli_with_base_url(
+            &server.base_url,
+            &[
+                "push-config",
+                "create",
+                "missing",
+                "https://example.com/callback",
+                "--config-id",
+                "cfg-missing",
+            ],
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::TASK_NOT_FOUND
+        ));
+
+        let err = run(parse_cli_with_base_url(
+            &server.base_url,
+            &["push-config", "list", "missing"],
+        ))
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            CliError::A2A(error) if error.code == a2a::error_code::TASK_NOT_FOUND
+        ));
+
+        let base_url = unused_base_url().await;
+        let err = run(parse_cli_with_base_url(&base_url, &["card"]))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CliError::Http(_)));
+    }
+
+    #[test]
+    fn test_task_state_conversion() {
+        let cases = [
+            (TaskStateArg::Unspecified, TaskState::Unspecified),
+            (TaskStateArg::Submitted, TaskState::Submitted),
+            (TaskStateArg::Working, TaskState::Working),
+            (TaskStateArg::Completed, TaskState::Completed),
+            (TaskStateArg::Failed, TaskState::Failed),
+            (TaskStateArg::Canceled, TaskState::Canceled),
+            (TaskStateArg::InputRequired, TaskState::InputRequired),
+            (TaskStateArg::Rejected, TaskState::Rejected),
+            (TaskStateArg::AuthRequired, TaskState::AuthRequired),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(TaskState::from(input), expected);
+        }
+    }
+}

--- a/a2acli/src/main.rs
+++ b/a2acli/src/main.rs
@@ -1,0 +1,19 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use clap::Parser;
+
+#[tokio::main]
+async fn main() {
+    let cli = a2acli::Cli::parse();
+    match a2acli::run(cli).await {
+        Ok(()) => {}
+        Err(a2acli::CliError::A2A(error)) => {
+            eprintln!("a2a error {}: {}", error.code, error.message);
+            std::process::exit(1);
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+    }
+}

--- a/a2acli/tests/e2e.rs
+++ b/a2acli/tests/e2e.rs
@@ -1,0 +1,712 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use std::collections::BTreeMap;
+use std::process::Command as StdCommand;
+use std::sync::{Arc, Mutex};
+
+use a2a::event::{StreamResponse, TaskStatusUpdateEvent};
+use a2a::*;
+use a2a_server::jsonrpc::jsonrpc_router;
+use a2a_server::rest::rest_router;
+use a2a_server::{RequestHandler, ServiceParams, WELL_KNOWN_AGENT_CARD_PATH};
+use assert_cmd::assert::OutputAssertExt;
+use assert_cmd::cargo::CommandCargoExt;
+use async_trait::async_trait;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::routing::get;
+use axum::{Json, Router};
+use futures::stream::{self, BoxStream};
+use serde_json::Value;
+use tokio::net::TcpListener;
+
+#[derive(Default)]
+struct ServerState {
+    tasks: Mutex<BTreeMap<String, Task>>,
+    push_configs: Mutex<BTreeMap<(String, String), TaskPushNotificationConfig>>,
+    card_headers: Mutex<Vec<(Option<String>, Option<String>)>>,
+}
+
+struct TestHandler {
+    state: Arc<ServerState>,
+    extended_card: AgentCard,
+}
+
+struct TestServer {
+    base_url: String,
+    state: Arc<ServerState>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+impl TestServer {
+    async fn spawn() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let state = Arc::new(ServerState::default());
+
+        {
+            let mut tasks = state.tasks.lock().unwrap();
+            tasks.insert(
+                "task-1".to_string(),
+                make_task("task-1", "ctx-1", TaskState::Completed, "seeded result"),
+            );
+        }
+
+        let public_card = make_agent_card(&base_url, "Fixture Agent");
+        let extended_card = make_agent_card(&base_url, "Fixture Agent (extended)");
+        let handler = Arc::new(TestHandler {
+            state: state.clone(),
+            extended_card,
+        });
+
+        let card_state = state.clone();
+        let card = public_card.clone();
+        let app = Router::new()
+            .route(
+                WELL_KNOWN_AGENT_CARD_PATH,
+                get(move |headers: HeaderMap| {
+                    let state = card_state.clone();
+                    let card = card.clone();
+                    async move {
+                        state.card_headers.lock().unwrap().push((
+                            headers
+                                .get(header::AUTHORIZATION)
+                                .and_then(|value| value.to_str().ok())
+                                .map(ToOwned::to_owned),
+                            headers
+                                .get("x-test")
+                                .and_then(|value| value.to_str().ok())
+                                .map(ToOwned::to_owned),
+                        ));
+                        (StatusCode::OK, Json(card))
+                    }
+                }),
+            )
+            .nest("/jsonrpc", jsonrpc_router(handler.clone()))
+            .nest("/rest", rest_router(handler));
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        TestServer {
+            base_url,
+            state,
+            handle,
+        }
+    }
+}
+
+#[async_trait]
+impl RequestHandler for TestHandler {
+    async fn send_message(
+        &self,
+        _params: &ServiceParams,
+        req: SendMessageRequest,
+    ) -> Result<SendMessageResponse, A2AError> {
+        let task_id = req
+            .message
+            .task_id
+            .clone()
+            .unwrap_or_else(|| "task-send".to_string());
+        let context_id = req
+            .message
+            .context_id
+            .clone()
+            .unwrap_or_else(|| "ctx-send".to_string());
+        let text = req.message.text().unwrap_or_default();
+        if text == "send-error" {
+            return Err(A2AError::invalid_request("send failed"));
+        }
+        let task = make_task(
+            &task_id,
+            &context_id,
+            TaskState::Completed,
+            &format!("Echo: {text}"),
+        );
+        self.state
+            .tasks
+            .lock()
+            .unwrap()
+            .insert(task_id.clone(), task.clone());
+        Ok(SendMessageResponse::Task(task))
+    }
+
+    async fn send_streaming_message(
+        &self,
+        _params: &ServiceParams,
+        req: SendMessageRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        let task_id = req
+            .message
+            .task_id
+            .clone()
+            .unwrap_or_else(|| "task-stream".to_string());
+        let context_id = req
+            .message
+            .context_id
+            .clone()
+            .unwrap_or_else(|| "ctx-stream".to_string());
+        let text = req.message.text().unwrap_or_default();
+        if text == "stream-error" {
+            return Ok(Box::pin(stream::once(async {
+                Err(A2AError::internal("stream failed"))
+            })));
+        }
+
+        let task = make_task(
+            &task_id,
+            &context_id,
+            TaskState::Completed,
+            &format!("Echo: {text}"),
+        );
+        self.state
+            .tasks
+            .lock()
+            .unwrap()
+            .insert(task_id.clone(), task.clone());
+
+        Ok(Box::pin(stream::iter(vec![
+            Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                task_id,
+                context_id,
+                status: TaskStatus {
+                    state: TaskState::Working,
+                    message: None,
+                    timestamp: None,
+                },
+                metadata: None,
+            })),
+            Ok(StreamResponse::Task(task)),
+        ])))
+    }
+
+    async fn get_task(
+        &self,
+        _params: &ServiceParams,
+        req: GetTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.state
+            .tasks
+            .lock()
+            .unwrap()
+            .get(&req.id)
+            .cloned()
+            .ok_or_else(|| A2AError::task_not_found(&req.id))
+    }
+
+    async fn list_tasks(
+        &self,
+        _params: &ServiceParams,
+        req: ListTasksRequest,
+    ) -> Result<ListTasksResponse, A2AError> {
+        if req.context_id.as_deref() == Some("error") {
+            return Err(A2AError::invalid_params("list failed"));
+        }
+
+        let tasks: Vec<Task> = self
+            .state
+            .tasks
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|task| {
+                req.context_id
+                    .as_ref()
+                    .is_none_or(|context_id| &task.context_id == context_id)
+            })
+            .filter(|task| {
+                req.status
+                    .as_ref()
+                    .is_none_or(|status| &task.status.state == status)
+            })
+            .cloned()
+            .collect();
+
+        Ok(ListTasksResponse {
+            total_size: tasks.len() as i32,
+            page_size: req.page_size.unwrap_or(tasks.len() as i32),
+            next_page_token: String::new(),
+            tasks,
+        })
+    }
+
+    async fn cancel_task(
+        &self,
+        _params: &ServiceParams,
+        req: CancelTaskRequest,
+    ) -> Result<Task, A2AError> {
+        let mut tasks = self.state.tasks.lock().unwrap();
+        let task = tasks
+            .get(&req.id)
+            .cloned()
+            .ok_or_else(|| A2AError::task_not_found(&req.id))?;
+        let canceled = make_task(&task.id, &task.context_id, TaskState::Canceled, "canceled");
+        tasks.insert(req.id, canceled.clone());
+        Ok(canceled)
+    }
+
+    async fn subscribe_to_task(
+        &self,
+        _params: &ServiceParams,
+        req: SubscribeToTaskRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        if req.id == "stream-error" {
+            return Ok(Box::pin(stream::once(async {
+                Err(A2AError::internal("stream failed"))
+            })));
+        }
+
+        let task = self
+            .state
+            .tasks
+            .lock()
+            .unwrap()
+            .get(&req.id)
+            .cloned()
+            .ok_or_else(|| A2AError::task_not_found(&req.id))?;
+
+        Ok(Box::pin(stream::iter(vec![
+            Ok(StreamResponse::StatusUpdate(TaskStatusUpdateEvent {
+                task_id: req.id.clone(),
+                context_id: task.context_id.clone(),
+                status: TaskStatus {
+                    state: TaskState::Working,
+                    message: None,
+                    timestamp: None,
+                },
+                metadata: None,
+            })),
+            Ok(StreamResponse::Task(task)),
+        ])))
+    }
+
+    async fn create_push_config(
+        &self,
+        _params: &ServiceParams,
+        req: CreateTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        if !self.state.tasks.lock().unwrap().contains_key(&req.task_id) {
+            return Err(A2AError::task_not_found(&req.task_id));
+        }
+
+        let mut config = req.config;
+        let config_id = config
+            .id
+            .clone()
+            .unwrap_or_else(|| "cfg-generated".to_string());
+        config.id = Some(config_id.clone());
+        let task_config = TaskPushNotificationConfig {
+            task_id: req.task_id.clone(),
+            config,
+            tenant: req.tenant,
+        };
+        self.state
+            .push_configs
+            .lock()
+            .unwrap()
+            .insert((req.task_id, config_id), task_config.clone());
+        Ok(task_config)
+    }
+
+    async fn get_push_config(
+        &self,
+        _params: &ServiceParams,
+        req: GetTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        self.state
+            .push_configs
+            .lock()
+            .unwrap()
+            .get(&(req.task_id.clone(), req.id.clone()))
+            .cloned()
+            .ok_or_else(|| A2AError::task_not_found(&req.task_id))
+    }
+
+    async fn list_push_configs(
+        &self,
+        _params: &ServiceParams,
+        req: ListTaskPushNotificationConfigsRequest,
+    ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+        if req.task_id == "missing" {
+            return Err(A2AError::task_not_found(&req.task_id));
+        }
+
+        let configs = self
+            .state
+            .push_configs
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|config| config.task_id == req.task_id)
+            .cloned()
+            .collect();
+        Ok(ListTaskPushNotificationConfigsResponse {
+            configs,
+            next_page_token: None,
+        })
+    }
+
+    async fn delete_push_config(
+        &self,
+        _params: &ServiceParams,
+        req: DeleteTaskPushNotificationConfigRequest,
+    ) -> Result<(), A2AError> {
+        let deleted = self
+            .state
+            .push_configs
+            .lock()
+            .unwrap()
+            .remove(&(req.task_id.clone(), req.id.clone()));
+        if deleted.is_none() {
+            return Err(A2AError::task_not_found(&req.task_id));
+        }
+        Ok(())
+    }
+
+    async fn get_extended_agent_card(
+        &self,
+        _params: &ServiceParams,
+        req: GetExtendedAgentCardRequest,
+    ) -> Result<AgentCard, A2AError> {
+        if req.tenant.as_deref() == Some("error") {
+            return Err(A2AError::unsupported_operation("extended card denied"));
+        }
+
+        Ok(self.extended_card.clone())
+    }
+}
+
+fn make_agent_card(base_url: &str, name: &str) -> AgentCard {
+    AgentCard {
+        name: name.to_string(),
+        description: "CLI integration fixture".to_string(),
+        version: VERSION.to_string(),
+        supported_interfaces: vec![
+            AgentInterface::new(format!("{base_url}/jsonrpc"), TRANSPORT_PROTOCOL_JSONRPC),
+            AgentInterface::new(format!("{base_url}/rest"), TRANSPORT_PROTOCOL_HTTP_JSON),
+        ],
+        capabilities: AgentCapabilities {
+            streaming: Some(true),
+            push_notifications: Some(true),
+            extensions: None,
+            extended_agent_card: Some(true),
+        },
+        default_input_modes: vec!["text/plain".to_string()],
+        default_output_modes: vec!["text/plain".to_string()],
+        skills: vec![],
+        provider: None,
+        documentation_url: None,
+        icon_url: None,
+        security_schemes: None,
+        security_requirements: None,
+        signatures: None,
+    }
+}
+
+fn make_task(task_id: &str, context_id: &str, state: TaskState, text: &str) -> Task {
+    Task {
+        id: task_id.to_string(),
+        context_id: context_id.to_string(),
+        status: TaskStatus {
+            state,
+            message: Some(Message {
+                message_id: format!("msg-{task_id}"),
+                context_id: Some(context_id.to_string()),
+                task_id: Some(task_id.to_string()),
+                role: Role::Agent,
+                parts: vec![Part::text(text)],
+                metadata: None,
+                extensions: None,
+                reference_task_ids: None,
+            }),
+            timestamp: None,
+        },
+        artifacts: None,
+        history: None,
+        metadata: None,
+    }
+}
+
+fn run_cli_success(server: &TestServer, args: &[&str]) -> String {
+    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
+    command.args(["--base-url", server.base_url.as_str()]);
+    command.args(args);
+    let output = command.assert().success().get_output().stdout.clone();
+    String::from_utf8(output).unwrap()
+}
+
+fn run_cli_failure(server: &TestServer, args: &[&str]) -> (String, String) {
+    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
+    command.args(["--base-url", server.base_url.as_str()]);
+    command.args(args);
+    let output = command.assert().failure().get_output().clone();
+    (
+        String::from_utf8(output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}
+
+fn parse_json_lines(output: &str) -> Vec<Value> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect()
+}
+
+async fn unused_base_url() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    drop(listener);
+    format!("http://{addr}")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn card_and_extended_card_commands_work() {
+    let server = TestServer::spawn().await;
+
+    let stdout = run_cli_success(
+        &server,
+        &[
+            "--bearer-token",
+            "secret",
+            "--header",
+            "X-Test: abc",
+            "card",
+        ],
+    );
+    let card: Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(card["name"], "Fixture Agent");
+
+    let headers = server.state.card_headers.lock().unwrap().clone();
+    assert_eq!(headers.len(), 1);
+    assert_eq!(headers[0].0.as_deref(), Some("Bearer secret"));
+    assert_eq!(headers[0].1.as_deref(), Some("abc"));
+
+    let compact = run_cli_success(
+        &server,
+        &["--binding", "http-json", "--compact", "extended-card"],
+    );
+    assert!(!compact.trim_end().contains('\n'));
+    let card: Value = serde_json::from_str(compact.trim()).unwrap();
+    assert_eq!(card["name"], "Fixture Agent (extended)");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn send_task_list_and_cancel_commands_work() {
+    let server = TestServer::spawn().await;
+
+    let send = run_cli_success(
+        &server,
+        &[
+            "--bearer-token",
+            "secret",
+            "--header",
+            "X-Trace: 123",
+            "send",
+            "hello from cli",
+            "--task-id",
+            "task-send",
+            "--context-id",
+            "ctx-send",
+            "--accept-output",
+            "text/plain",
+            "--return-immediately",
+        ],
+    );
+    let send_json: Value = serde_json::from_str(&send).unwrap();
+    assert_eq!(send_json["task"]["id"], "task-send");
+    assert_eq!(
+        send_json["task"]["status"]["message"]["parts"][0]["text"],
+        "Echo: hello from cli"
+    );
+
+    let get_task = run_cli_success(&server, &["get-task", "task-send", "--history-length", "1"]);
+    let task_json: Value = serde_json::from_str(&get_task).unwrap();
+    assert_eq!(task_json["id"], "task-send");
+
+    let list = run_cli_success(
+        &server,
+        &[
+            "--compact",
+            "list-tasks",
+            "--context-id",
+            "ctx-send",
+            "--status",
+            "completed",
+        ],
+    );
+    let list_json: Value = serde_json::from_str(list.trim()).unwrap();
+    assert_eq!(list_json["tasks"].as_array().unwrap().len(), 1);
+
+    let cancel = run_cli_success(&server, &["cancel-task", "task-send"]);
+    let cancel_json: Value = serde_json::from_str(&cancel).unwrap();
+    assert_eq!(cancel_json["status"]["state"], "TASK_STATE_CANCELED");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stream_and_subscribe_commands_work() {
+    let server = TestServer::spawn().await;
+
+    let stream_output = run_cli_success(
+        &server,
+        &[
+            "--compact",
+            "stream",
+            "streaming request",
+            "--task-id",
+            "task-stream",
+            "--context-id",
+            "ctx-stream",
+        ],
+    );
+    let stream_events = parse_json_lines(&stream_output);
+    assert_eq!(stream_events.len(), 2);
+    assert_eq!(
+        stream_events[0]["statusUpdate"]["status"]["state"],
+        "TASK_STATE_WORKING"
+    );
+    assert_eq!(stream_events[1]["task"]["id"], "task-stream");
+
+    let subscribe_output = run_cli_success(&server, &["--compact", "subscribe", "task-stream"]);
+    let subscribe_events = parse_json_lines(&subscribe_output);
+    assert_eq!(subscribe_events.len(), 2);
+    assert_eq!(subscribe_events[1]["task"]["id"], "task-stream");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn push_config_crud_commands_work() {
+    let server = TestServer::spawn().await;
+
+    let create = run_cli_success(
+        &server,
+        &[
+            "--compact",
+            "--tenant",
+            "tenant-1",
+            "push-config",
+            "create",
+            "task-1",
+            "https://example.com/callback",
+            "--config-id",
+            "cfg-1",
+            "--token",
+            "tok-1",
+            "--auth-scheme",
+            "Bearer",
+            "--auth-credentials",
+            "secret",
+        ],
+    );
+    let create_json: Value = serde_json::from_str(create.trim()).unwrap();
+    assert_eq!(create_json["taskId"], "task-1");
+    assert_eq!(create_json["config"]["id"], "cfg-1");
+    assert_eq!(create_json["tenant"], "tenant-1");
+
+    let get = run_cli_success(
+        &server,
+        &["--compact", "push-config", "get", "task-1", "cfg-1"],
+    );
+    let get_json: Value = serde_json::from_str(get.trim()).unwrap();
+    assert_eq!(get_json["config"]["authentication"]["scheme"], "Bearer");
+
+    let list = run_cli_success(
+        &server,
+        &[
+            "--compact",
+            "push-config",
+            "list",
+            "task-1",
+            "--page-size",
+            "10",
+        ],
+    );
+    let list_json: Value = serde_json::from_str(list.trim()).unwrap();
+    assert_eq!(list_json["configs"].as_array().unwrap().len(), 1);
+
+    let delete = run_cli_success(
+        &server,
+        &["--compact", "push-config", "delete", "task-1", "cfg-1"],
+    );
+    let delete_json: Value = serde_json::from_str(delete.trim()).unwrap();
+    assert_eq!(delete_json["deleted"], true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn binary_reports_a2a_and_non_a2a_errors() {
+    let server = TestServer::spawn().await;
+
+    let base_url = unused_base_url().await;
+    let mut command = StdCommand::cargo_bin("a2acli").unwrap();
+    let output = command
+        .args(["--base-url", base_url.as_str(), "card"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("http request failed:"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["extended-card", "--tenant", "error"]);
+    assert!(stderr.contains("a2a error -32004: extended card denied"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["send", "send-error"]);
+    assert!(stderr.contains("a2a error -32600: send failed"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["list-tasks", "--context-id", "error"]);
+    assert!(stderr.contains("a2a error -32602: list failed"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["get-task", "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: missing"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["cancel-task", "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: missing"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["subscribe", "stream-error"]);
+    assert!(stderr.contains("a2a error -32603: stream failed"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["--compact", "stream", "stream-error"]);
+    assert!(stderr.contains("a2a error -32603: stream failed"));
+
+    let (_stdout, stderr) = run_cli_failure(
+        &server,
+        &[
+            "push-config",
+            "create",
+            "missing",
+            "https://example.com/callback",
+            "--config-id",
+            "cfg-missing",
+        ],
+    );
+    assert!(stderr.contains("a2a error -32001: task not found: missing"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["push-config", "get", "task-1", "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: task-1"));
+
+    let (_stdout, stderr) = run_cli_failure(&server, &["push-config", "list", "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: missing"));
+
+    let (_stdout, stderr) =
+        run_cli_failure(&server, &["push-config", "delete", "task-1", "missing"]);
+    assert!(stderr.contains("a2a error -32001: task not found: task-1"));
+
+    let (_stdout, stderr) = run_cli_failure(
+        &server,
+        &[
+            "push-config",
+            "create",
+            "task-1",
+            "https://example.com/callback",
+            "--auth-credentials",
+            "secret",
+        ],
+    );
+    assert!(stderr.contains("invalid input: --auth-credentials requires --auth-scheme"));
+}


### PR DESCRIPTION
Closes #37

## Summary

Adds a standalone A2A CLI as a new workspace crate, published as agntcy-a2acli and installed as the a2acli binary.

This PR includes:
- fetching the public agent card and extended agent card
- sending one-shot and streaming messages
- getting, listing, canceling, and subscribing to tasks
- creating, getting, listing, and deleting push notification configs
- bearer-token and custom-header request propagation
- workspace and crate documentation for install and usage
- a changelog entry for the new package

Companion fixes included in this branch:
- a2a-client now applies interceptor before/after hooks consistently around transport calls
- agent-card and agent-skill securityRequirements deserialization now accepts wrapped spec-style shapes for compatibility

## Validation

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test -p agntcy-a2acli
- LLVM_COV=$(xcrun --find llvm-cov) LLVM_PROFDATA=$(xcrun --find llvm-profdata) cargo llvm-cov -p agntcy-a2acli --summary-only

agntcy-a2acli coverage:
- 95.63% region coverage
- 98.95% line coverage
