### PR TITLE
feat: migrate A2A crates to a2a-lf namespace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ please join us!
 For any issue, there are fundamentally three ways an individual can contribute:
 
 1. By opening the issue for discussion: For instance, if you believe that you
-   have discovered a bug in A2A-RS, creating a new issue in [the agntcy/a2a-rs
+   have discovered a bug in A2A-RS, creating a new issue in [the a2aproject/a2a-rs
    issue tracker][issue] is the way to report it.
 
 2. By helping to triage the issue: This can be done by providing
@@ -35,7 +35,7 @@ For any issue, there are fundamentally three ways an individual can contribute:
    often, by opening a Pull Request that changes some bit of something in
    A2A-RS in a concrete and reviewable manner.
 
-[issue]: https://github.com/agntcy/a2a-rs/issues
+[issue]: https://github.com/a2aproject/a2a-rs/issues
 
 **Anybody can participate in any stage of contribution**. We urge you to
 participate in the discussion around bugs and participate in reviewing PRs.
@@ -48,7 +48,7 @@ having problems, you can [open a discussion] asking for help.
 In exchange for receiving help, we ask that you contribute back a documentation
 PR that helps others avoid the problems that you encountered.
 
-[open a discussion]: https://github.com/agntcy/a2a-rs/discussions/new
+[open a discussion]: https://github.com/a2aproject/a2a-rs/discussions/new
 
 ### Submitting a Bug Report
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 version = 4
 
 [[package]]
-name = "agntcy-a2a"
+name = "a2aproj-a2a-rs"
 version = "0.2.4"
 dependencies = [
  "base64 0.22.1",
@@ -15,11 +15,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-a2a-client"
+name = "a2aproj-a2a-rs-cli"
+version = "0.1.0"
+dependencies = [
+ "a2aproj-a2a-rs",
+ "a2aproj-a2a-rs-client",
+ "a2aproj-a2a-rs-server",
+ "assert_cmd",
+ "async-trait",
+ "axum",
+ "clap",
+ "futures",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "a2aproj-a2a-rs-client"
 version = "0.1.13"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-pb",
+ "a2aproj-a2a-rs",
+ "a2aproj-a2a-rs-pb",
  "async-trait",
  "bytes",
  "futures",
@@ -35,13 +54,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-a2a-grpc"
+name = "a2aproj-a2a-rs-grpc"
 version = "0.1.11"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-pb",
- "agntcy-a2a-server",
+ "a2aproj-a2a-rs",
+ "a2aproj-a2a-rs-client",
+ "a2aproj-a2a-rs-pb",
+ "a2aproj-a2a-rs-server",
  "async-trait",
  "futures",
  "prost 0.13.5",
@@ -52,10 +71,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-a2a-pb"
+name = "a2aproj-a2a-rs-pb"
 version = "0.1.6"
 dependencies = [
- "agntcy-a2a",
+ "a2aproj-a2a-rs",
  "chrono",
  "pbjson",
  "pbjson-build",
@@ -70,11 +89,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-a2a-server"
+name = "a2aproj-a2a-rs-server"
 version = "0.2.6"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-pb",
+ "a2aproj-a2a-rs",
+ "a2aproj-a2a-rs-pb",
  "async-trait",
  "axum",
  "chrono",
@@ -93,37 +112,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-a2a-slimrpc"
+name = "a2aproj-a2a-rs-slimrpc"
 version = "0.1.8"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-pb",
- "agntcy-a2a-server",
+ "a2aproj-a2a-rs",
+ "a2aproj-a2a-rs-client",
+ "a2aproj-a2a-rs-pb",
+ "a2aproj-a2a-rs-server",
  "agntcy-slim-bindings",
  "async-trait",
  "futures",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "tokio",
-]
-
-[[package]]
-name = "agntcy-a2acli"
-version = "0.1.0"
-dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-server",
- "assert_cmd",
- "async-trait",
- "axum",
- "clap",
- "futures",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -1565,9 +1565,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "helloworld"
 version = "0.1.0"
 dependencies = [
- "agntcy-a2a",
- "agntcy-a2a-client",
- "agntcy-a2a-server",
+ "a2aproj-a2a-rs",
+ "a2aproj-a2a-rs-client",
+ "a2aproj-a2a-rs-server",
  "async-trait",
  "axum",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,24 +3,12 @@
 version = 4
 
 [[package]]
-name = "a2aproj-a2a-rs"
-version = "0.2.4"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "uuid",
-]
-
-[[package]]
-name = "a2aproj-a2a-rs-cli"
+name = "a2a-cli"
 version = "0.1.0"
 dependencies = [
- "a2aproj-a2a-rs",
- "a2aproj-a2a-rs-client",
- "a2aproj-a2a-rs-server",
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-server-lf",
  "assert_cmd",
  "async-trait",
  "axum",
@@ -34,11 +22,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2aproj-a2a-rs-client"
+name = "a2a-client-lf"
 version = "0.1.13"
 dependencies = [
- "a2aproj-a2a-rs",
- "a2aproj-a2a-rs-pb",
+ "a2a-lf",
+ "a2a-pb",
  "async-trait",
  "bytes",
  "futures",
@@ -54,13 +42,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2aproj-a2a-rs-grpc"
+name = "a2a-grpc"
 version = "0.1.11"
 dependencies = [
- "a2aproj-a2a-rs",
- "a2aproj-a2a-rs-client",
- "a2aproj-a2a-rs-pb",
- "a2aproj-a2a-rs-server",
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-pb",
+ "a2a-server-lf",
  "async-trait",
  "futures",
  "prost 0.13.5",
@@ -71,10 +59,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2aproj-a2a-rs-pb"
+name = "a2a-lf"
+version = "0.2.4"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "a2a-pb"
 version = "0.1.6"
 dependencies = [
- "a2aproj-a2a-rs",
+ "a2a-lf",
  "chrono",
  "pbjson",
  "pbjson-build",
@@ -89,11 +89,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2aproj-a2a-rs-server"
+name = "a2a-server-lf"
 version = "0.2.6"
 dependencies = [
- "a2aproj-a2a-rs",
- "a2aproj-a2a-rs-pb",
+ "a2a-lf",
+ "a2a-pb",
  "async-trait",
  "axum",
  "chrono",
@@ -112,13 +112,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "a2aproj-a2a-rs-slimrpc"
+name = "a2a-slimrpc"
 version = "0.1.8"
 dependencies = [
- "a2aproj-a2a-rs",
- "a2aproj-a2a-rs-client",
- "a2aproj-a2a-rs-pb",
- "a2aproj-a2a-rs-server",
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-pb",
+ "a2a-server-lf",
  "agntcy-slim-bindings",
  "async-trait",
  "futures",
@@ -174,7 +174,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prost-types 0.14.3",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest",
  "schemars",
  "serde",
@@ -291,7 +291,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "protoc-bin-vendored",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -323,7 +323,7 @@ dependencies = [
  "parking_lot",
  "prost 0.14.3",
  "protoc-bin-vendored",
- "rand 0.9.2",
+ "rand 0.9.4",
  "semver",
  "serde",
  "serde_json",
@@ -398,7 +398,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde",
  "thiserror 2.0.18",
  "tokio",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -749,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -819,9 +819,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -889,9 +889,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1260,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1527,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "headers"
@@ -1565,9 +1565,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "helloworld"
 version = "0.1.0"
 dependencies = [
- "a2aproj-a2a-rs",
- "a2aproj-a2a-rs-client",
- "a2aproj-a2a-rs-server",
+ "a2a-client-lf",
+ "a2a-lf",
+ "a2a-server-lf",
  "async-trait",
  "axum",
  "chrono",
@@ -1664,15 +1664,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1874,12 +1873,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1890,7 +1889,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -1982,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2058,9 +2057,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2373,7 +2372,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -2391,7 +2390,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -2490,11 +2489,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2522,9 +2521,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -2619,7 +2618,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2760,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3072,7 +3071,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "memchr",
  "unicase",
 ]
@@ -3115,7 +3114,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3175,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3223,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3247,7 +3246,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3391,7 +3390,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3400,9 +3399,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3438,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3535,7 +3534,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3554,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -3875,7 +3874,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4025,9 +4024,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -4270,7 +4269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -4406,7 +4405,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -4710,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4723,9 +4722,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4733,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4743,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4756,9 +4755,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4804,7 +4803,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4812,9 +4811,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5173,7 +5172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,17 +14,17 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-repository = "https://github.com/agntcy/a2a-rs"
+repository = "https://github.com/a2aproject/a2a-rs"
 rust-version = "1.85"
 
 [workspace.dependencies]
 # Internal crates
-a2a = { package = "agntcy-a2a", path = "a2a", version = "0.2.4" }
-a2a-client = { package = "agntcy-a2a-client", path = "a2a-client", version = "0.1.13" }
-a2a-server = { package = "agntcy-a2a-server", path = "a2a-server", version = "0.2.6" }
-a2a-pb = { package = "agntcy-a2a-pb", path = "a2a-pb", version = "0.1.6" }
-a2a-grpc = { package = "agntcy-a2a-grpc", path = "a2a-grpc", version = "0.1.11" }
-a2a-slimrpc = { package = "agntcy-a2a-slimrpc", path = "a2a-slimrpc", version = "0.1.8" }
+a2a = { package = "a2aproj-a2a-rs", path = "a2a", version = "0.2.4" }
+a2a-client = { package = "a2aproj-a2a-rs-client", path = "a2a-client", version = "0.1.13" }
+a2a-server = { package = "a2aproj-a2a-rs-server", path = "a2a-server", version = "0.2.6" }
+a2a-pb = { package = "a2aproj-a2a-rs-pb", path = "a2a-pb", version = "0.1.6" }
+a2a-grpc = { package = "a2aproj-a2a-rs-grpc", path = "a2a-grpc", version = "0.1.11" }
+a2a-slimrpc = { package = "a2aproj-a2a-rs-slimrpc", path = "a2a-slimrpc", version = "0.1.8" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ rust-version = "1.85"
 
 [workspace.dependencies]
 # Internal crates
-a2a = { package = "a2aproj-a2a-rs", path = "a2a", version = "0.2.4" }
-a2a-client = { package = "a2aproj-a2a-rs-client", path = "a2a-client", version = "0.1.13" }
-a2a-server = { package = "a2aproj-a2a-rs-server", path = "a2a-server", version = "0.2.6" }
-a2a-pb = { package = "a2aproj-a2a-rs-pb", path = "a2a-pb", version = "0.1.6" }
-a2a-grpc = { package = "a2aproj-a2a-rs-grpc", path = "a2a-grpc", version = "0.1.11" }
-a2a-slimrpc = { package = "a2aproj-a2a-rs-slimrpc", path = "a2a-slimrpc", version = "0.1.8" }
+a2a = { package = "a2a-lf", path = "a2a", version = "0.2.4" }
+a2a-client = { package = "a2a-client-lf", path = "a2a-client", version = "0.1.13" }
+a2a-server = { package = "a2a-server-lf", path = "a2a-server", version = "0.2.6" }
+a2a-pb = { package = "a2a-pb", path = "a2a-pb", version = "0.1.6" }
+a2a-grpc = { package = "a2a-grpc", path = "a2a-grpc", version = "0.1.11" }
+a2a-slimrpc = { package = "a2a-slimrpc", path = "a2a-slimrpc", version = "0.1.8" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # A2A Rust SDK
 
-[![CI](https://github.com/agntcy/a2a-rs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/agntcy/a2a-rs/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/agntcy/a2a-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/agntcy/a2a-rs)
-[![crates.io](https://img.shields.io/crates/v/agntcy-a2a.svg)](https://crates.io/crates/agntcy-a2a)
-[![docs.rs](https://docs.rs/agntcy-a2a/badge.svg)](https://docs.rs/agntcy-a2a)
-[![License](https://img.shields.io/crates/l/agntcy-a2a.svg)](https://github.com/agntcy/a2a-rs/blob/main/LICENSE.md)
+[![CI](https://github.com/a2aproject/a2a-rs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/a2aproject/a2a-rs/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/a2aproject/a2a-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/a2aproject/a2a-rs)
+[![crates.io](https://img.shields.io/crates/v/a2aproj-a2a-rs.svg)](https://crates.io/crates/a2aproj-a2a-rs)
+[![docs.rs](https://docs.rs/a2aproj-a2a-rs/badge.svg)](https://docs.rs/a2aproj-a2a-rs)
+[![License](https://img.shields.io/crates/l/a2aproj-a2a-rs.svg)](https://github.com/a2aproject/a2a-rs/blob/main/LICENSE.md)
 
 `a2a-rs` is a Rust workspace for the A2A v1 protocol. It includes core protocol
 types, async client and server libraries, protobuf definitions, and gRPC
@@ -29,7 +29,7 @@ The workspace supports:
 | `a2a-pb` | Protobuf schema, generated types, ProtoJSON-capable generated types, and native <-> protobuf conversion helpers |
 | `a2a-grpc` | gRPC client and server bindings built on `tonic` |
 | `a2a-slimrpc` | SLIMRPC client and server bindings built on `slim_bindings` |
-| `a2acli` | Standalone A2A client CLI, published as `agntcy-a2acli`, for inspecting agent cards, sending messages, managing tasks, and handling push configs |
+| `a2acli` | Standalone A2A client CLI, published as `a2aproj-a2a-rs-cli`, for inspecting agent cards, sending messages, managing tasks, and handling push configs |
 | `examples/helloworld` | Minimal runnable example agent |
 
 ## Supported Bindings
@@ -124,7 +124,7 @@ transport selection, and pass `--bearer-token` or repeated `--header Name:Value`
 arguments when the server requires authentication.
 
 Install from the workspace with `cargo install --path a2acli`, or from crates.io
-after release with `cargo install agntcy-a2acli`.
+after release with `cargo install a2aproj-a2a-rs-cli`.
 
 ## Depending On The Workspace
 
@@ -132,12 +132,12 @@ Until the crates are published, depend on them directly from Git:
 
 ```toml
 [dependencies]
-a2a = { package = "agntcy-a2a", git = "https://github.com/agntcy/a2a-rs.git" }
-a2a-client = { package = "agntcy-a2a-client", git = "https://github.com/agntcy/a2a-rs.git" }
-a2a-server = { package = "agntcy-a2a-server", git = "https://github.com/agntcy/a2a-rs.git" }
-a2a-pb = { package = "agntcy-a2a-pb", git = "https://github.com/agntcy/a2a-rs.git" }
-a2a-grpc = { package = "agntcy-a2a-grpc", git = "https://github.com/agntcy/a2a-rs.git" }
-a2a-slimrpc = { package = "agntcy-a2a-slimrpc", git = "https://github.com/agntcy/a2a-rs.git" }
+a2a = { package = "a2aproj-a2a-rs", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-client = { package = "a2aproj-a2a-rs-client", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-server = { package = "a2aproj-a2a-rs-server", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-pb = { package = "a2aproj-a2a-rs-pb", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-grpc = { package = "a2aproj-a2a-rs-grpc", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-slimrpc = { package = "a2aproj-a2a-rs-slimrpc", git = "https://github.com/a2aproject/a2a-rs.git" }
 ```
 
 Typical usage is:

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI](https://github.com/a2aproject/a2a-rs/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/a2aproject/a2a-rs/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/a2aproject/a2a-rs/branch/main/graph/badge.svg)](https://codecov.io/gh/a2aproject/a2a-rs)
-[![crates.io](https://img.shields.io/crates/v/a2aproj-a2a-rs.svg)](https://crates.io/crates/a2aproj-a2a-rs)
-[![docs.rs](https://docs.rs/a2aproj-a2a-rs/badge.svg)](https://docs.rs/a2aproj-a2a-rs)
-[![License](https://img.shields.io/crates/l/a2aproj-a2a-rs.svg)](https://github.com/a2aproject/a2a-rs/blob/main/LICENSE.md)
+[![crates.io](https://img.shields.io/crates/v/a2a-lf.svg)](https://crates.io/crates/a2a-lf)
+[![docs.rs](https://docs.rs/a2a-lf/badge.svg)](https://docs.rs/a2a-lf)
+[![License](https://img.shields.io/crates/l/a2a-lf.svg)](https://github.com/a2aproject/a2a-rs/blob/main/LICENSE.md)
 
 `a2a-rs` is a Rust workspace for the A2A v1 protocol. It includes core protocol
 types, async client and server libraries, protobuf definitions, and gRPC
@@ -29,7 +29,7 @@ The workspace supports:
 | `a2a-pb` | Protobuf schema, generated types, ProtoJSON-capable generated types, and native <-> protobuf conversion helpers |
 | `a2a-grpc` | gRPC client and server bindings built on `tonic` |
 | `a2a-slimrpc` | SLIMRPC client and server bindings built on `slim_bindings` |
-| `a2acli` | Standalone A2A client CLI, published as `a2aproj-a2a-rs-cli`, for inspecting agent cards, sending messages, managing tasks, and handling push configs |
+| `a2acli` | Standalone A2A client CLI, published as `a2a-cli`, for inspecting agent cards, sending messages, managing tasks, and handling push configs |
 | `examples/helloworld` | Minimal runnable example agent |
 
 ## Supported Bindings
@@ -124,7 +124,7 @@ transport selection, and pass `--bearer-token` or repeated `--header Name:Value`
 arguments when the server requires authentication.
 
 Install from the workspace with `cargo install --path a2acli`, or from crates.io
-after release with `cargo install a2aproj-a2a-rs-cli`.
+after release with `cargo install a2a-cli`.
 
 ## Depending On The Workspace
 
@@ -132,12 +132,12 @@ Until the crates are published, depend on them directly from Git:
 
 ```toml
 [dependencies]
-a2a = { package = "a2aproj-a2a-rs", git = "https://github.com/a2aproject/a2a-rs.git" }
-a2a-client = { package = "a2aproj-a2a-rs-client", git = "https://github.com/a2aproject/a2a-rs.git" }
-a2a-server = { package = "a2aproj-a2a-rs-server", git = "https://github.com/a2aproject/a2a-rs.git" }
-a2a-pb = { package = "a2aproj-a2a-rs-pb", git = "https://github.com/a2aproject/a2a-rs.git" }
-a2a-grpc = { package = "a2aproj-a2a-rs-grpc", git = "https://github.com/a2aproject/a2a-rs.git" }
-a2a-slimrpc = { package = "a2aproj-a2a-rs-slimrpc", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a = { package = "a2a-lf", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-client = { package = "a2a-client-lf", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-server = { package = "a2a-server-lf", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-pb = { package = "a2a-pb", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-grpc = { package = "a2a-grpc", git = "https://github.com/a2aproject/a2a-rs.git" }
+a2a-slimrpc = { package = "a2a-slimrpc", git = "https://github.com/a2aproject/a2a-rs.git" }
 ```
 
 Typical usage is:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,5 +21,5 @@ Participation in security issue coordination processes is at the discretion of t
 ## Security advisories
 
 The project team is committed to transparency in the security issue disclosure
-process. The A2A Rust SDK team announces security issues via [project GitHub Release notes](https://github.com/agntcy/a2a-rs/releases)
+process. The A2A Rust SDK team announces security issues via [project GitHub Release notes](https://github.com/a2aproject/a2a-rs/releases)
 and the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`).

--- a/a2a-client/CHANGELOG.md
+++ b/a2a-client/CHANGELOG.md
@@ -7,37 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.13](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.12...agntcy-a2a-client-v0.1.13) - 2026-04-06
+## [0.1.13](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.12...agntcy-a2a-client-v0.1.13) - 2026-04-06
 
 ### Fixed
 
-- *(client)* serialize create-push requests for go interop ([#35](https://github.com/agntcy/a2a-rs/pull/35))
+- *(client)* serialize create-push requests for go interop ([#35](https://github.com/a2aproject/a2a-rs/pull/35))
 
-## [0.1.12](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.11...agntcy-a2a-client-v0.1.12) - 2026-04-06
+## [0.1.12](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.11...agntcy-a2a-client-v0.1.12) - 2026-04-06
 
 ### Other
 
-- apply rustfmt to interop changes ([#33](https://github.com/agntcy/a2a-rs/pull/33))
+- apply rustfmt to interop changes ([#33](https://github.com/a2aproject/a2a-rs/pull/33))
 
-## [0.1.11](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.10...agntcy-a2a-client-v0.1.11) - 2026-04-06
+## [0.1.11](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.10...agntcy-a2a-client-v0.1.11) - 2026-04-06
 
 ### Fixed
 
-- *(interop)* align push-config JSON bindings with a2a-go ([#31](https://github.com/agntcy/a2a-rs/pull/31))
+- *(interop)* align push-config JSON bindings with a2a-go ([#31](https://github.com/a2aproject/a2a-rs/pull/31))
 
-## [0.1.10](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.9...agntcy-a2a-client-v0.1.10) - 2026-04-06
+## [0.1.10](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.9...agntcy-a2a-client-v0.1.10) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-pb
 
-## [0.1.9](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.8...agntcy-a2a-client-v0.1.9) - 2026-04-05
+## [0.1.9](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.8...agntcy-a2a-client-v0.1.9) - 2026-04-05
 
 ### Other
 
 - updated the following local packages: agntcy-a2a, agntcy-a2a-pb
 
-## [0.1.8](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.7...agntcy-a2a-client-v0.1.8) - 2026-04-05
+## [0.1.8](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.7...agntcy-a2a-client-v0.1.8) - 2026-04-05
 
 ### Added
 
@@ -47,32 +47,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - format ProtoJSON transport changes
 
-## [0.1.7](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.6...agntcy-a2a-client-v0.1.7) - 2026-04-04
+## [0.1.7](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.6...agntcy-a2a-client-v0.1.7) - 2026-04-04
 
 ### Fixed
 
 - align HTTP+JSON REST interop
 
-## [0.1.6](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.5...agntcy-a2a-client-v0.1.6) - 2026-04-04
+## [0.1.6](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.5...agntcy-a2a-client-v0.1.6) - 2026-04-04
 
 ### Fixed
 
 - drop dotted jsonrpc aliases
 - align jsonrpc and agent-card interop
 
-## [0.1.5](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.4...agntcy-a2a-client-v0.1.5) - 2026-04-03
+## [0.1.5](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.4...agntcy-a2a-client-v0.1.5) - 2026-04-03
 
 ### Other
 
 - updated the following local packages: agntcy-a2a
 
-## [0.1.4](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-client-v0.1.3...agntcy-a2a-client-v0.1.4) - 2026-04-03
+## [0.1.4](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-client-v0.1.3...agntcy-a2a-client-v0.1.4) - 2026-04-03
 
 ### Other
 
 - add crate readmes for crates.io
 
-## [0.1.3](https://github.com/agntcy/a2a-rs/compare/a2a-client-v0.1.2...a2a-client-v0.1.3) - 2026-04-03
+## [0.1.3](https://github.com/a2aproject/a2a-rs/compare/a2a-client-v0.1.2...a2a-client-v0.1.3) - 2026-04-03
 
 ### Added
 
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - release
 - release
 
-## [0.1.2](https://github.com/agntcy/a2a-rs/compare/a2a-client-v0.1.1...a2a-client-v0.1.2) - 2026-04-03
+## [0.1.2](https://github.com/a2aproject/a2a-rs/compare/a2a-client-v0.1.1...a2a-client-v0.1.2) - 2026-04-03
 
 ### Added
 
@@ -93,7 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - release
 
-## [0.1.1](https://github.com/agntcy/a2a-rs/compare/a2a-client-v0.1.0...a2a-client-v0.1.1) - 2026-04-03
+## [0.1.1](https://github.com/a2aproject/a2a-rs/compare/a2a-client-v0.1.0...a2a-client-v0.1.1) - 2026-04-03
 
 ### Added
 

--- a/a2a-client/Cargo.toml
+++ b/a2a-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agntcy-a2a-client"
+name = "a2aproj-a2a-rs-client"
 version = "0.1.13"
 description = "A2A v1 async client with protocol binding factory"
 readme = "README.md"

--- a/a2a-client/Cargo.toml
+++ b/a2a-client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "a2aproj-a2a-rs-client"
+name = "a2a-client-lf"
 version = "0.1.13"
 description = "A2A v1 async client with protocol binding factory"
 readme = "README.md"

--- a/a2a-client/README.md
+++ b/a2a-client/README.md
@@ -1,8 +1,8 @@
-# agntcy-a2a-client
+# a2aproj-a2a-rs-client
 
 Async Rust client for A2A v1 agents.
 
-This crate is published as `agntcy-a2a-client` and imported in Rust as `a2a_client`.
+This crate is published as `a2aproj-a2a-rs-client` and imported in Rust as `a2a_client`.
 
 ## What It Provides
 
@@ -15,13 +15,13 @@ This crate is published as `agntcy-a2a-client` and imported in Rust as `a2a_clie
 
 ```toml
 [dependencies]
-a2a = { package = "agntcy-a2a", version = "0.2" }
-a2a-client = { package = "agntcy-a2a-client", version = "0.1" }
+a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
+a2a-client = { package = "a2aproj-a2a-rs-client", version = "0.1" }
 ```
 
 ## Workspace
 
 This crate is part of the `a2a-rs` workspace.
 
-- Repository: https://github.com/agntcy/a2a-rs
-- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md
+- Repository: https://github.com/a2aproject/a2a-rs
+- Workspace README: https://github.com/a2aproject/a2a-rs/blob/main/README.md

--- a/a2a-client/README.md
+++ b/a2a-client/README.md
@@ -1,8 +1,8 @@
-# a2aproj-a2a-rs-client
+# a2a-client-lf
 
 Async Rust client for A2A v1 agents.
 
-This crate is published as `a2aproj-a2a-rs-client` and imported in Rust as `a2a_client`.
+This crate is published as `a2a-client-lf` and imported in Rust as `a2a_client`.
 
 ## What It Provides
 
@@ -15,8 +15,8 @@ This crate is published as `a2aproj-a2a-rs-client` and imported in Rust as `a2a_
 
 ```toml
 [dependencies]
-a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
-a2a-client = { package = "a2aproj-a2a-rs-client", version = "0.1" }
+a2a = { package = "a2a-lf", version = "0.2" }
+a2a-client = { package = "a2a-client-lf", version = "0.1" }
 ```
 
 ## Workspace

--- a/a2a-grpc/CHANGELOG.md
+++ b/a2a-grpc/CHANGELOG.md
@@ -7,43 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.11](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.10...agntcy-a2a-grpc-v0.1.11) - 2026-04-06
+## [0.1.11](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.10...agntcy-a2a-grpc-v0.1.11) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client
 
-## [0.1.10](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.9...agntcy-a2a-grpc-v0.1.10) - 2026-04-06
+## [0.1.10](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.9...agntcy-a2a-grpc-v0.1.10) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.9](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.8...agntcy-a2a-grpc-v0.1.9) - 2026-04-06
+## [0.1.9](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.8...agntcy-a2a-grpc-v0.1.9) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.8](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.7...agntcy-a2a-grpc-v0.1.8) - 2026-04-06
+## [0.1.8](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.7...agntcy-a2a-grpc-v0.1.8) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-server
 
-## [0.1.7](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.6...agntcy-a2a-grpc-v0.1.7) - 2026-04-06
+## [0.1.7](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.6...agntcy-a2a-grpc-v0.1.7) - 2026-04-06
 
 ### Added
 
 - *(server)* support push configs and gRPC list interop
 
-## [0.1.6](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.5...agntcy-a2a-grpc-v0.1.6) - 2026-04-05
+## [0.1.6](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.5...agntcy-a2a-grpc-v0.1.6) - 2026-04-05
 
 ### Fixed
 
 - normalize gRPC agent card URLs
 
-## [0.1.5](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.4...agntcy-a2a-grpc-v0.1.5) - 2026-04-05
+## [0.1.5](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.4...agntcy-a2a-grpc-v0.1.5) - 2026-04-05
 
 ### Fixed
 
@@ -53,31 +53,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - avoid serializing gRPC client calls
 
-## [0.1.4](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.3...agntcy-a2a-grpc-v0.1.4) - 2026-04-04
+## [0.1.4](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.3...agntcy-a2a-grpc-v0.1.4) - 2026-04-04
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.3](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.2...agntcy-a2a-grpc-v0.1.3) - 2026-04-04
+## [0.1.3](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.2...agntcy-a2a-grpc-v0.1.3) - 2026-04-04
 
 ### Other
 
 - updated the following local packages: agntcy-a2a, agntcy-a2a-client, agntcy-a2a-server, agntcy-a2a-pb
 
-## [0.1.2](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.1...agntcy-a2a-grpc-v0.1.2) - 2026-04-03
+## [0.1.2](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.1...agntcy-a2a-grpc-v0.1.2) - 2026-04-03
 
 ### Other
 
 - updated the following local packages: agntcy-a2a, agntcy-a2a-client, agntcy-a2a-server, agntcy-a2a-pb
 
-## [0.1.1](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-grpc-v0.1.0...agntcy-a2a-grpc-v0.1.1) - 2026-04-03
+## [0.1.1](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-grpc-v0.1.0...agntcy-a2a-grpc-v0.1.1) - 2026-04-03
 
 ### Other
 
 - add crate readmes for crates.io
 
-## [0.1.0](https://github.com/agntcy/a2a-rs/releases/tag/a2a-grpc-v0.1.0) - 2026-04-03
+## [0.1.0](https://github.com/a2aproject/a2a-rs/releases/tag/a2a-grpc-v0.1.0) - 2026-04-03
 
 ### Added
 

--- a/a2a-grpc/Cargo.toml
+++ b/a2a-grpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agntcy-a2a-grpc"
+name = "a2aproj-a2a-rs-grpc"
 version = "0.1.11"
 description = "A2A v1 gRPC protocol binding for client and server"
 readme = "README.md"

--- a/a2a-grpc/Cargo.toml
+++ b/a2a-grpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "a2aproj-a2a-rs-grpc"
+name = "a2a-grpc"
 version = "0.1.11"
 description = "A2A v1 gRPC protocol binding for client and server"
 readme = "README.md"

--- a/a2a-grpc/README.md
+++ b/a2a-grpc/README.md
@@ -1,8 +1,8 @@
-# a2aproj-a2a-rs-grpc
+# a2a-grpc
 
 gRPC bindings for A2A v1 client and server implementations.
 
-This crate is published as `a2aproj-a2a-rs-grpc` and imported in Rust as `a2a_grpc`.
+This crate is published as `a2a-grpc` and imported in Rust as `a2a_grpc`.
 
 ## What It Provides
 
@@ -20,8 +20,8 @@ before connecting so agent cards emitted by other SDKs remain usable.
 
 ```toml
 [dependencies]
-a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
-a2a-grpc = { package = "a2aproj-a2a-rs-grpc", version = "0.1" }
+a2a = { package = "a2a-lf", version = "0.2" }
+a2a-grpc = { package = "a2a-grpc", version = "0.1" }
 ```
 
 ## Workspace

--- a/a2a-grpc/README.md
+++ b/a2a-grpc/README.md
@@ -1,8 +1,8 @@
-# agntcy-a2a-grpc
+# a2aproj-a2a-rs-grpc
 
 gRPC bindings for A2A v1 client and server implementations.
 
-This crate is published as `agntcy-a2a-grpc` and imported in Rust as `a2a_grpc`.
+This crate is published as `a2aproj-a2a-rs-grpc` and imported in Rust as `a2a_grpc`.
 
 ## What It Provides
 
@@ -20,13 +20,13 @@ before connecting so agent cards emitted by other SDKs remain usable.
 
 ```toml
 [dependencies]
-a2a = { package = "agntcy-a2a", version = "0.2" }
-a2a-grpc = { package = "agntcy-a2a-grpc", version = "0.1" }
+a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
+a2a-grpc = { package = "a2aproj-a2a-rs-grpc", version = "0.1" }
 ```
 
 ## Workspace
 
 This crate is part of the `a2a-rs` workspace.
 
-- Repository: https://github.com/agntcy/a2a-rs
-- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md
+- Repository: https://github.com/a2aproject/a2a-rs
+- Workspace README: https://github.com/a2aproject/a2a-rs/blob/main/README.md

--- a/a2a-pb/CHANGELOG.md
+++ b/a2a-pb/CHANGELOG.md
@@ -7,19 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.6](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-pb-v0.1.5...agntcy-a2a-pb-v0.1.6) - 2026-04-06
+## [0.1.6](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-pb-v0.1.5...agntcy-a2a-pb-v0.1.6) - 2026-04-06
 
 ### Added
 
 - *(server)* support push configs and gRPC list interop
 
-## [0.1.5](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-pb-v0.1.4...agntcy-a2a-pb-v0.1.5) - 2026-04-05
+## [0.1.5](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-pb-v0.1.4...agntcy-a2a-pb-v0.1.5) - 2026-04-05
 
 ### Fixed
 
 - normalize gRPC agent card URLs
 
-## [0.1.4](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-pb-v0.1.3...agntcy-a2a-pb-v0.1.4) - 2026-04-05
+## [0.1.4](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-pb-v0.1.3...agntcy-a2a-pb-v0.1.4) - 2026-04-05
 
 ### Added
 
@@ -33,25 +33,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - format ProtoJSON transport changes
 
-## [0.1.3](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-pb-v0.1.2...agntcy-a2a-pb-v0.1.3) - 2026-04-04
+## [0.1.3](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-pb-v0.1.2...agntcy-a2a-pb-v0.1.3) - 2026-04-04
 
 ### Other
 
 - updated the following local packages: agntcy-a2a
 
-## [0.1.2](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-pb-v0.1.1...agntcy-a2a-pb-v0.1.2) - 2026-04-03
+## [0.1.2](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-pb-v0.1.1...agntcy-a2a-pb-v0.1.2) - 2026-04-03
 
 ### Other
 
 - updated the following local packages: agntcy-a2a
 
-## [0.1.1](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-pb-v0.1.0...agntcy-a2a-pb-v0.1.1) - 2026-04-03
+## [0.1.1](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-pb-v0.1.0...agntcy-a2a-pb-v0.1.1) - 2026-04-03
 
 ### Other
 
 - add crate readmes for crates.io
 
-## [0.1.0](https://github.com/agntcy/a2a-rs/releases/tag/a2a-pb-v0.1.0) - 2026-04-03
+## [0.1.0](https://github.com/a2aproject/a2a-rs/releases/tag/a2a-pb-v0.1.0) - 2026-04-03
 
 ### Added
 

--- a/a2a-pb/Cargo.toml
+++ b/a2a-pb/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agntcy-a2a-pb"
+name = "a2aproj-a2a-rs-pb"
 version = "0.1.6"
 description = "A2A v1 protobuf-generated types and conversion layer"
 readme = "README.md"

--- a/a2a-pb/Cargo.toml
+++ b/a2a-pb/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "a2aproj-a2a-rs-pb"
+name = "a2a-pb"
 version = "0.1.6"
 description = "A2A v1 protobuf-generated types and conversion layer"
 readme = "README.md"

--- a/a2a-pb/README.md
+++ b/a2a-pb/README.md
@@ -1,8 +1,8 @@
-# agntcy-a2a-pb
+# a2aproj-a2a-rs-pb
 
 Protobuf schema and conversion helpers for A2A v1.
 
-This crate is published as `agntcy-a2a-pb` and imported in Rust as `a2a_pb`.
+This crate is published as `a2aproj-a2a-rs-pb` and imported in Rust as `a2a_pb`.
 
 ## What It Provides
 
@@ -15,13 +15,13 @@ This crate is published as `agntcy-a2a-pb` and imported in Rust as `a2a_pb`.
 
 ```toml
 [dependencies]
-a2a = { package = "agntcy-a2a", version = "0.2" }
-a2a-pb = { package = "agntcy-a2a-pb", version = "0.1" }
+a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
+a2a-pb = { package = "a2aproj-a2a-rs-pb", version = "0.1" }
 ```
 
 ## Workspace
 
 This crate is part of the `a2a-rs` workspace.
 
-- Repository: https://github.com/agntcy/a2a-rs
-- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md
+- Repository: https://github.com/a2aproject/a2a-rs
+- Workspace README: https://github.com/a2aproject/a2a-rs/blob/main/README.md

--- a/a2a-pb/README.md
+++ b/a2a-pb/README.md
@@ -1,8 +1,8 @@
-# a2aproj-a2a-rs-pb
+# a2a-pb
 
 Protobuf schema and conversion helpers for A2A v1.
 
-This crate is published as `a2aproj-a2a-rs-pb` and imported in Rust as `a2a_pb`.
+This crate is published as `a2a-pb` and imported in Rust as `a2a_pb`.
 
 ## What It Provides
 
@@ -15,8 +15,8 @@ This crate is published as `a2aproj-a2a-rs-pb` and imported in Rust as `a2a_pb`.
 
 ```toml
 [dependencies]
-a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
-a2a-pb = { package = "a2aproj-a2a-rs-pb", version = "0.1" }
+a2a = { package = "a2a-lf", version = "0.2" }
+a2a-pb = { package = "a2a-pb", version = "0.1" }
 ```
 
 ## Workspace

--- a/a2a-server/CHANGELOG.md
+++ b/a2a-server/CHANGELOG.md
@@ -7,37 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.6](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.2.5...agntcy-a2a-server-v0.2.6) - 2026-04-06
+## [0.2.6](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.2.5...agntcy-a2a-server-v0.2.6) - 2026-04-06
 
 ### Other
 
-- apply rustfmt to interop changes ([#33](https://github.com/agntcy/a2a-rs/pull/33))
+- apply rustfmt to interop changes ([#33](https://github.com/a2aproject/a2a-rs/pull/33))
 
-## [0.2.5](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.2.4...agntcy-a2a-server-v0.2.5) - 2026-04-06
+## [0.2.5](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.2.4...agntcy-a2a-server-v0.2.5) - 2026-04-06
 
 ### Fixed
 
-- *(interop)* align push-config JSON bindings with a2a-go ([#31](https://github.com/agntcy/a2a-rs/pull/31))
+- *(interop)* align push-config JSON bindings with a2a-go ([#31](https://github.com/a2aproject/a2a-rs/pull/31))
 
-## [0.2.4](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.2.3...agntcy-a2a-server-v0.2.4) - 2026-04-06
+## [0.2.4](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.2.3...agntcy-a2a-server-v0.2.4) - 2026-04-06
 
 ### Added
 
 - *(a2a-server)* support resumable subscriptions and push delivery
 
-## [0.2.3](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.2.2...agntcy-a2a-server-v0.2.3) - 2026-04-06
+## [0.2.3](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.2.2...agntcy-a2a-server-v0.2.3) - 2026-04-06
 
 ### Added
 
 - *(server)* support push configs and gRPC list interop
 
-## [0.2.2](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.2.1...agntcy-a2a-server-v0.2.2) - 2026-04-05
+## [0.2.2](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.2.1...agntcy-a2a-server-v0.2.2) - 2026-04-05
 
 ### Other
 
 - updated the following local packages: agntcy-a2a, agntcy-a2a-pb
 
-## [0.2.1](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.2.0...agntcy-a2a-server-v0.2.1) - 2026-04-05
+## [0.2.1](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.2.0...agntcy-a2a-server-v0.2.1) - 2026-04-05
 
 ### Added
 
@@ -47,32 +47,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - format ProtoJSON transport changes
 
-## [0.2.0](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.1.3...agntcy-a2a-server-v0.2.0) - 2026-04-04
+## [0.2.0](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.1.3...agntcy-a2a-server-v0.2.0) - 2026-04-04
 
 ### Fixed
 
 - align HTTP+JSON REST interop
 
-## [0.1.3](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.1.2...agntcy-a2a-server-v0.1.3) - 2026-04-04
+## [0.1.3](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.1.2...agntcy-a2a-server-v0.1.3) - 2026-04-04
 
 ### Fixed
 
 - drop dotted jsonrpc aliases
 - align jsonrpc and agent-card interop
 
-## [0.1.2](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.1.1...agntcy-a2a-server-v0.1.2) - 2026-04-03
+## [0.1.2](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.1.1...agntcy-a2a-server-v0.1.2) - 2026-04-03
 
 ### Other
 
 - updated the following local packages: agntcy-a2a
 
-## [0.1.1](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-server-v0.1.0...agntcy-a2a-server-v0.1.1) - 2026-04-03
+## [0.1.1](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-server-v0.1.0...agntcy-a2a-server-v0.1.1) - 2026-04-03
 
 ### Other
 
 - add crate readmes for crates.io
 
-## [0.1.0](https://github.com/agntcy/a2a-rs/releases/tag/a2a-server-v0.1.0) - 2026-04-03
+## [0.1.0](https://github.com/a2aproject/a2a-rs/releases/tag/a2a-server-v0.1.0) - 2026-04-03
 
 ### Added
 

--- a/a2a-server/Cargo.toml
+++ b/a2a-server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "a2aproj-a2a-rs-server"
+name = "a2a-server-lf"
 version = "0.2.6"
 description = "A2A v1 async server framework"
 readme = "README.md"

--- a/a2a-server/Cargo.toml
+++ b/a2a-server/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agntcy-a2a-server"
+name = "a2aproj-a2a-rs-server"
 version = "0.2.6"
 description = "A2A v1 async server framework"
 readme = "README.md"

--- a/a2a-server/README.md
+++ b/a2a-server/README.md
@@ -1,8 +1,8 @@
-# a2aproj-a2a-rs-server
+# a2a-server-lf
 
 Async server framework for implementing A2A v1 agents in Rust.
 
-This crate is published as `a2aproj-a2a-rs-server` and imported in Rust as `a2a_server`.
+This crate is published as `a2a-server-lf` and imported in Rust as `a2a_server`.
 
 ## What It Provides
 
@@ -15,8 +15,8 @@ This crate is published as `a2aproj-a2a-rs-server` and imported in Rust as `a2a_
 
 ```toml
 [dependencies]
-a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
-a2a-server = { package = "a2aproj-a2a-rs-server", version = "0.1" }
+a2a = { package = "a2a-lf", version = "0.2" }
+a2a-server = { package = "a2a-server-lf", version = "0.1" }
 ```
 
 ## Workspace

--- a/a2a-server/README.md
+++ b/a2a-server/README.md
@@ -1,8 +1,8 @@
-# agntcy-a2a-server
+# a2aproj-a2a-rs-server
 
 Async server framework for implementing A2A v1 agents in Rust.
 
-This crate is published as `agntcy-a2a-server` and imported in Rust as `a2a_server`.
+This crate is published as `a2aproj-a2a-rs-server` and imported in Rust as `a2a_server`.
 
 ## What It Provides
 
@@ -15,13 +15,13 @@ This crate is published as `agntcy-a2a-server` and imported in Rust as `a2a_serv
 
 ```toml
 [dependencies]
-a2a = { package = "agntcy-a2a", version = "0.2" }
-a2a-server = { package = "agntcy-a2a-server", version = "0.1" }
+a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
+a2a-server = { package = "a2aproj-a2a-rs-server", version = "0.1" }
 ```
 
 ## Workspace
 
 This crate is part of the `a2a-rs` workspace.
 
-- Repository: https://github.com/agntcy/a2a-rs
-- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md
+- Repository: https://github.com/a2aproject/a2a-rs
+- Workspace README: https://github.com/a2aproject/a2a-rs/blob/main/README.md

--- a/a2a-slimrpc/CHANGELOG.md
+++ b/a2a-slimrpc/CHANGELOG.md
@@ -7,55 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.8](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.7...agntcy-a2a-slimrpc-v0.1.8) - 2026-04-06
+## [0.1.8](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.7...agntcy-a2a-slimrpc-v0.1.8) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client
 
-## [0.1.7](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.6...agntcy-a2a-slimrpc-v0.1.7) - 2026-04-06
+## [0.1.7](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.6...agntcy-a2a-slimrpc-v0.1.7) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.6](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.5...agntcy-a2a-slimrpc-v0.1.6) - 2026-04-06
+## [0.1.6](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.5...agntcy-a2a-slimrpc-v0.1.6) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.5](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.4...agntcy-a2a-slimrpc-v0.1.5) - 2026-04-06
+## [0.1.5](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.4...agntcy-a2a-slimrpc-v0.1.5) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-server
 
-## [0.1.4](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.3...agntcy-a2a-slimrpc-v0.1.4) - 2026-04-06
+## [0.1.4](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.3...agntcy-a2a-slimrpc-v0.1.4) - 2026-04-06
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-pb, agntcy-a2a-server, agntcy-a2a-client
 
-## [0.1.3](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.2...agntcy-a2a-slimrpc-v0.1.3) - 2026-04-05
+## [0.1.3](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.2...agntcy-a2a-slimrpc-v0.1.3) - 2026-04-05
 
 ### Other
 
 - updated the following local packages: agntcy-a2a, agntcy-a2a-pb, agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.2](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.1...agntcy-a2a-slimrpc-v0.1.2) - 2026-04-05
+## [0.1.2](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.1...agntcy-a2a-slimrpc-v0.1.2) - 2026-04-05
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-pb, agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.1](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.0...agntcy-a2a-slimrpc-v0.1.1) - 2026-04-04
+## [0.1.1](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-slimrpc-v0.1.0...agntcy-a2a-slimrpc-v0.1.1) - 2026-04-04
 
 ### Other
 
 - updated the following local packages: agntcy-a2a-client, agntcy-a2a-server
 
-## [0.1.0](https://github.com/agntcy/a2a-rs/releases/tag/agntcy-a2a-slimrpc-v0.1.0) - 2026-04-04
+## [0.1.0](https://github.com/a2aproject/a2a-rs/releases/tag/agntcy-a2a-slimrpc-v0.1.0) - 2026-04-04
 
 ### Added
 

--- a/a2a-slimrpc/Cargo.toml
+++ b/a2a-slimrpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "a2aproj-a2a-rs-slimrpc"
+name = "a2a-slimrpc"
 version = "0.1.8"
 description = "A2A v1 SLIMRPC protocol binding for client and server"
 readme = "README.md"

--- a/a2a-slimrpc/Cargo.toml
+++ b/a2a-slimrpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agntcy-a2a-slimrpc"
+name = "a2aproj-a2a-rs-slimrpc"
 version = "0.1.8"
 description = "A2A v1 SLIMRPC protocol binding for client and server"
 readme = "README.md"

--- a/a2a-slimrpc/README.md
+++ b/a2a-slimrpc/README.md
@@ -1,8 +1,8 @@
-# agntcy-a2a-slimrpc
+# a2aproj-a2a-rs-slimrpc
 
 SLIMRPC bindings for A2A v1 client and server implementations.
 
-This crate is published as `agntcy-a2a-slimrpc` and imported in Rust as `a2a_slimrpc`.
+This crate is published as `a2aproj-a2a-rs-slimrpc` and imported in Rust as `a2a_slimrpc`.
 
 ## What It Provides
 
@@ -25,13 +25,13 @@ Accepted forms are:
 
 ```toml
 [dependencies]
-a2a = { package = "agntcy-a2a", version = "0.2" }
-a2a-slimrpc = { package = "agntcy-a2a-slimrpc", version = "0.1" }
+a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
+a2a-slimrpc = { package = "a2aproj-a2a-rs-slimrpc", version = "0.1" }
 ```
 
 ## Workspace
 
 This crate is part of the `a2a-rs` workspace.
 
-- Repository: https://github.com/agntcy/a2a-rs
-- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md
+- Repository: https://github.com/a2aproject/a2a-rs
+- Workspace README: https://github.com/a2aproject/a2a-rs/blob/main/README.md

--- a/a2a-slimrpc/README.md
+++ b/a2a-slimrpc/README.md
@@ -1,8 +1,8 @@
-# a2aproj-a2a-rs-slimrpc
+# a2a-slimrpc
 
 SLIMRPC bindings for A2A v1 client and server implementations.
 
-This crate is published as `a2aproj-a2a-rs-slimrpc` and imported in Rust as `a2a_slimrpc`.
+This crate is published as `a2a-slimrpc` and imported in Rust as `a2a_slimrpc`.
 
 ## What It Provides
 
@@ -25,8 +25,8 @@ Accepted forms are:
 
 ```toml
 [dependencies]
-a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
-a2a-slimrpc = { package = "a2aproj-a2a-rs-slimrpc", version = "0.1" }
+a2a = { package = "a2a-lf", version = "0.2" }
+a2a-slimrpc = { package = "a2a-slimrpc", version = "0.1" }
 ```
 
 ## Workspace

--- a/a2a/CHANGELOG.md
+++ b/a2a/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.4](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-v0.2.3...agntcy-a2a-v0.2.4) - 2026-04-05
+## [0.2.4](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-v0.2.3...agntcy-a2a-v0.2.4) - 2026-04-05
 
 ### Fixed
 
 - normalize gRPC agent card URLs
 
-## [0.2.3](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-v0.2.2...agntcy-a2a-v0.2.3) - 2026-04-04
+## [0.2.3](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-v0.2.2...agntcy-a2a-v0.2.3) - 2026-04-04
 
 ### Added
 
@@ -24,19 +24,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - drop dotted jsonrpc aliases
 - align jsonrpc and agent-card interop
 
-## [0.2.2](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-v0.2.1...agntcy-a2a-v0.2.2) - 2026-04-03
+## [0.2.2](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-v0.2.1...agntcy-a2a-v0.2.2) - 2026-04-03
 
 ### Other
 
 - add crate rustdoc for agntcy-a2a
 
-## [0.2.1](https://github.com/agntcy/a2a-rs/compare/agntcy-a2a-v0.2.0...agntcy-a2a-v0.2.1) - 2026-04-03
+## [0.2.1](https://github.com/a2aproject/a2a-rs/compare/agntcy-a2a-v0.2.0...agntcy-a2a-v0.2.1) - 2026-04-03
 
 ### Other
 
 - add crate readmes for crates.io
 
-## [0.2.0](https://github.com/agntcy/a2a-rs/compare/a2a-v0.1.0...a2a-v0.2.0) - 2026-04-03
+## [0.2.0](https://github.com/a2aproject/a2a-rs/compare/a2a-v0.1.0...a2a-v0.2.0) - 2026-04-03
 
 ### Added
 

--- a/a2a/Cargo.toml
+++ b/a2a/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "a2aproj-a2a-rs"
+name = "a2a-lf"
 version = "0.2.4"
 description = "A2A v1 protocol types and core definitions"
 readme = "README.md"

--- a/a2a/Cargo.toml
+++ b/a2a/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agntcy-a2a"
+name = "a2aproj-a2a-rs"
 version = "0.2.4"
 description = "A2A v1 protocol types and core definitions"
 readme = "README.md"

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -1,8 +1,8 @@
-# agntcy-a2a
+# a2aproj-a2a-rs
 
 Core Rust types for the A2A v1 protocol.
 
-This crate is published as `agntcy-a2a` and imported in Rust as `a2a`.
+This crate is published as `a2aproj-a2a-rs` and imported in Rust as `a2a`.
 
 ## What It Provides
 
@@ -15,7 +15,7 @@ This crate is published as `agntcy-a2a` and imported in Rust as `a2a`.
 
 ```toml
 [dependencies]
-a2a = { package = "agntcy-a2a", version = "0.2" }
+a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
 ```
 
 ## Example
@@ -31,5 +31,5 @@ assert_eq!(message.text(), Some("hello"));
 
 This crate is part of the `a2a-rs` workspace.
 
-- Repository: https://github.com/agntcy/a2a-rs
-- Workspace README: https://github.com/agntcy/a2a-rs/blob/main/README.md
+- Repository: https://github.com/a2aproject/a2a-rs
+- Workspace README: https://github.com/a2aproject/a2a-rs/blob/main/README.md

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -1,8 +1,8 @@
-# a2aproj-a2a-rs
+# a2a-lf
 
 Core Rust types for the A2A v1 protocol.
 
-This crate is published as `a2aproj-a2a-rs` and imported in Rust as `a2a`.
+This crate is published as `a2a-lf` and imported in Rust as `a2a`.
 
 ## What It Provides
 
@@ -15,7 +15,7 @@ This crate is published as `a2aproj-a2a-rs` and imported in Rust as `a2a`.
 
 ```toml
 [dependencies]
-a2a = { package = "a2aproj-a2a-rs", version = "0.2" }
+a2a = { package = "a2a-lf", version = "0.2" }
 ```
 
 ## Example

--- a/a2acli/CHANGELOG.md
+++ b/a2acli/CHANGELOG.md
@@ -11,4 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add standalone `a2acli` binary crate
 - add task push notification config CRUD commands
-- make the package installable as `a2aproj-a2a-rs-cli`
+- make the package installable as `a2a-cli`

--- a/a2acli/CHANGELOG.md
+++ b/a2acli/CHANGELOG.md
@@ -11,4 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add standalone `a2acli` binary crate
 - add task push notification config CRUD commands
-- make the package installable as `agntcy-a2acli`
+- make the package installable as `a2aproj-a2a-rs-cli`

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agntcy-a2acli"
+name = "a2aproj-a2a-rs-cli"
 version = "0.1.0"
 description = "Standalone A2A CLI client"
 readme = "README.md"

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "a2aproj-a2a-rs-cli"
+name = "a2a-cli"
 version = "0.1.0"
 description = "Standalone A2A CLI client"
 readme = "README.md"

--- a/a2acli/README.md
+++ b/a2acli/README.md
@@ -2,7 +2,7 @@
 
 Standalone A2A CLI client built on top of `a2a-client`.
 
-This crate is published as `a2aproj-a2a-rs-cli` and installs the `a2acli` binary.
+This crate is published as `a2a-cli` and installs the `a2acli` binary.
 
 ## Install
 
@@ -15,7 +15,7 @@ cargo install --path a2acli
 From crates.io after release:
 
 ```sh
-cargo install a2aproj-a2a-rs-cli
+cargo install a2a-cli
 ```
 
 ## What It Provides

--- a/a2acli/README.md
+++ b/a2acli/README.md
@@ -2,7 +2,7 @@
 
 Standalone A2A CLI client built on top of `a2a-client`.
 
-This crate is published as `agntcy-a2acli` and installs the `a2acli` binary.
+This crate is published as `a2aproj-a2a-rs-cli` and installs the `a2acli` binary.
 
 ## Install
 
@@ -15,7 +15,7 @@ cargo install --path a2acli
 From crates.io after release:
 
 ```sh
-cargo install agntcy-a2acli
+cargo install a2aproj-a2a-rs-cli
 ```
 
 ## What It Provides

--- a/examples/helloworld/src/main.rs
+++ b/examples/helloworld/src/main.rs
@@ -87,7 +87,7 @@ fn build_agent_card() -> AgentCard {
         version: a2a::VERSION.to_string(),
         provider: Some(AgentProvider {
             organization: "A2A Rust SDK".to_string(),
-            url: "https://github.com/agntcy/a2a-rs".to_string(),
+            url: "https://github.com/a2aproject/a2a-rs".to_string(),
         }),
         capabilities: AgentCapabilities {
             streaming: Some(true),


### PR DESCRIPTION
## Summary
- rename published A2A crate package names from `agntcy-a2a*` to `a2a-lf*`
- keep historical changelog tag names and release references unchanged where they refer to past published artifacts

## Validation
- `cargo test --workspace --quiet`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
