### PR TITLE
feat: use rustls everywhere and expose TLS backend selection via feature flags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-**/ @agntcy/rustaceans
+**/ @a2aproject/rustaceans

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,11 +97,13 @@ dependencies = [
  "a2a-pb",
  "async-trait",
  "axum",
+ "axum-server",
  "chrono",
  "futures",
  "http-body-util",
  "hyper",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "tokio",
@@ -522,6 +524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "askama"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +779,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err 3.3.0",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1331,6 +1364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -4477,7 +4520,7 @@ dependencies = [
  "askama",
  "camino",
  "cargo_metadata",
- "fs-err",
+ "fs-err 2.11.0",
  "glob",
  "goblin",
  "heck",
@@ -4536,7 +4579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
 dependencies = [
  "camino",
- "fs-err",
+ "fs-err 2.11.0",
  "once_cell",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,10 +41,12 @@ pin-project-lite = "0.2"
 
 # HTTP
 axum = { version = "0.8", features = ["macros"] }
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "charset", "http2", "system-proxy"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
 hyper = "1"
+axum-server = "0.8"
+rustls = "0.23"
 
 # gRPC + protobuf
 tonic = "0.13"

--- a/a2a-client/Cargo.toml
+++ b/a2a-client/Cargo.toml
@@ -27,3 +27,8 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 semver = { workspace = true }
 pin-project-lite = { workspace = true }
+
+[features]
+default = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]

--- a/a2a-client/src/rest.rs
+++ b/a2a-client/src/rest.rs
@@ -267,7 +267,7 @@ fn parse_rest_error(status: reqwest::StatusCode, body: &str) -> A2AError {
         }
 
         if let Value::Object(values) = raw_detail {
-            details.extend(values.into_iter());
+            details.extend(values);
         }
     }
 

--- a/a2a-server/Cargo.toml
+++ b/a2a-server/Cargo.toml
@@ -28,6 +28,14 @@ reqwest = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+axum-server = { workspace = true, features = ["tls-rustls"], optional = true }
+rustls = { workspace = true, optional = true }
+
+[features]
+default = ["rustls-tls"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
+rustls = ["dep:axum-server", "dep:rustls", "rustls-tls"]
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/a2a-server/src/lib.rs
+++ b/a2a-server/src/lib.rs
@@ -10,6 +10,8 @@ mod push_config_compat;
 pub mod rest;
 pub mod sse;
 pub mod task_store;
+#[cfg(feature = "rustls")]
+pub mod tls;
 
 pub use agent_card::{AgentCardProducer, StaticAgentCard, WELL_KNOWN_AGENT_CARD_PATH};
 pub use executor::{AgentExecutor, ExecutorContext};

--- a/a2a-server/src/tls.rs
+++ b/a2a-server/src/tls.rs
@@ -1,0 +1,33 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Re-exports for serving axum routers over HTTPS with rustls.
+//!
+//! This module is available when the `rustls` feature is enabled. It
+//! re-exports compatible versions of [`rustls`] and [`axum_server`] so that
+//! consumers do not need to manually align dependency versions.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use a2a_server::tls::{axum_server, rustls};
+//!
+//! # async fn example() {
+//! let tls_config = rustls::ServerConfig::builder()
+//!     .with_no_client_auth()
+//!     .with_single_cert(vec![], rustls::pki_types::PrivateKeyDer::Pkcs8(vec![].into()))
+//!     .unwrap();
+//!
+//! let app = axum::Router::new();
+//! let rustls_config = axum_server::tls_rustls::RustlsConfig::from_config(Arc::new(tls_config));
+//! let addr: std::net::SocketAddr = "0.0.0.0:3443".parse().unwrap();
+//! axum_server::bind_rustls(addr, rustls_config)
+//!     .serve(app.into_make_service())
+//!     .await
+//!     .unwrap();
+//! # }
+//! ```
+
+pub use axum_server;
+pub use rustls;

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -26,6 +26,11 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 
+[features]
+default = ["rustls-tls"]
+native-tls = ["a2a-client/native-tls", "reqwest/native-tls"]
+rustls-tls = ["a2a-client/rustls-tls", "reqwest/rustls-tls"]
+
 [dev-dependencies]
 a2a-server = { workspace = true }
 assert_cmd = "2"


### PR DESCRIPTION
Remove implicit native-tls dependency from reqwest by disabling its default features at the workspace level. Each crate that uses reqwest (a2a-client, a2a-server, a2acli) now exposes feature flags to select the TLS backend:

  default = ["rustls-tls"]
  native-tls = ["reqwest/native-tls"]
  rustls-tls = ["reqwest/rustls-tls"]

Additionally, a2a-server gains a "rustls" feature that pulls in axum-server with rustls support and re-exports both rustls and axum_server crates via a new tls module, so consumers can serve over HTTPS without manually aligning dependency versions.

Fixes: #45 