### PR TITLE
fix: align error code mappings with upstream spec fix (A2A#1627)

### DIFF
--- a/a2a-client/src/jsonrpc.rs
+++ b/a2a-client/src/jsonrpc.rs
@@ -7,12 +7,31 @@ use futures::stream::{self, BoxStream, StreamExt};
 use reqwest::Client;
 use std::collections::VecDeque;
 
+use serde_json::Value;
+
 use crate::push_config_compat::{
     deserialize_list_task_push_notification_configs_response,
     deserialize_task_push_notification_config,
     serialize_create_task_push_notification_config_request,
 };
 use crate::transport::{ServiceParams, Transport, TransportFactory};
+
+fn parse_jsonrpc_error(err: JsonRpcError) -> A2AError {
+    let details: Vec<TypedDetail> = err
+        .data
+        .and_then(|data| match data {
+            Value::Array(a) => Some(a),
+            _ => None,
+        })
+        .map(|arr| {
+            arr.into_iter()
+                .filter_map(|v| serde_json::from_value::<TypedDetail>(v).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    crate::a2a_error_from_details(err.code, err.message, details)
+}
 
 /// JSON-RPC transport implementation.
 ///
@@ -56,7 +75,7 @@ impl JsonRpcTransport {
             .map_err(|e| A2AError::internal(format!("failed to parse JSON-RPC response: {e}")))?;
 
         if let Some(err) = rpc_response.error {
-            return Err(A2AError::new(err.code, err.message));
+            return Err(parse_jsonrpc_error(err));
         }
 
         rpc_response
@@ -240,7 +259,7 @@ fn parse_sse_stream(
         match serde_json::from_str::<JsonRpcResponse>(&data) {
             Ok(rpc_resp) => {
                 if let Some(err) = rpc_resp.error {
-                    return Some(Err(A2AError::new(err.code, err.message)));
+                    return Some(Err(parse_jsonrpc_error(err)));
                 }
                 if let Some(result) = rpc_resp.result {
                     match protojson_conv::from_value::<StreamResponse>(result) {
@@ -411,7 +430,7 @@ impl Transport for JsonRpcTransport {
             .map_err(|e| A2AError::internal(format!("failed to parse JSON-RPC response: {e}")))?;
 
         if let Some(err) = rpc_response.error {
-            return Err(A2AError::new(err.code, err.message));
+            return Err(parse_jsonrpc_error(err));
         }
 
         Ok(())
@@ -1314,5 +1333,159 @@ mod tests {
         let iface = AgentInterface::new("https://localhost:3443/jsonrpc", "JSONRPC");
         let transport = f.create(&card, &iface).await.unwrap();
         transport.destroy().await.unwrap();
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_no_data() {
+        let err = JsonRpcError {
+            code: error_code::TASK_NOT_FOUND,
+            message: "task not found".into(),
+            data: None,
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        assert_eq!(a2a_err.code, error_code::TASK_NOT_FOUND);
+        assert_eq!(a2a_err.message, "task not found");
+        assert!(a2a_err.details.is_none());
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_non_array_data() {
+        let err = JsonRpcError {
+            code: error_code::INTERNAL_ERROR,
+            message: "err".into(),
+            data: Some(json!("just a string")),
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        assert_eq!(a2a_err.code, error_code::INTERNAL_ERROR);
+        assert!(a2a_err.details.is_none());
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_with_error_info() {
+        let err = JsonRpcError {
+            code: error_code::INTERNAL_ERROR,
+            message: "task not found: t1".into(),
+            data: Some(json!([
+                {
+                    "@type": errordetails::ERROR_INFO_TYPE,
+                    "reason": "TASK_NOT_FOUND",
+                    "domain": errordetails::PROTOCOL_DOMAIN,
+                    "metadata": {"taskId": "t1"}
+                }
+            ])),
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        assert_eq!(a2a_err.code, error_code::TASK_NOT_FOUND);
+        assert_eq!(a2a_err.message, "task not found: t1");
+        let details = a2a_err.details.unwrap();
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0].type_url, errordetails::ERROR_INFO_TYPE);
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_with_bad_request() {
+        let err = JsonRpcError {
+            code: error_code::INTERNAL_ERROR,
+            message: "invalid params".into(),
+            data: Some(json!([
+                {
+                    "@type": errordetails::BAD_REQUEST_TYPE,
+                    "fieldViolations": [
+                        {"field": "message.parts", "description": "required"},
+                        {"field": "message.role", "description": "must be user or agent"}
+                    ]
+                }
+            ])),
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        assert_eq!(a2a_err.code, error_code::INVALID_PARAMS);
+        assert!(a2a_err.message.contains("message.parts: required"));
+        assert!(
+            a2a_err
+                .message
+                .contains("message.role: must be user or agent")
+        );
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_bad_request_does_not_override_explicit_code() {
+        let err = JsonRpcError {
+            code: error_code::PARSE_ERROR,
+            message: "parse error".into(),
+            data: Some(json!([
+                {
+                    "@type": errordetails::BAD_REQUEST_TYPE,
+                    "fieldViolations": [
+                        {"field": "body", "description": "invalid json"}
+                    ]
+                }
+            ])),
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        // BadRequest only overrides INTERNAL_ERROR, not other codes
+        assert_eq!(a2a_err.code, error_code::PARSE_ERROR);
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_error_info_overrides_bad_request_code() {
+        let err = JsonRpcError {
+            code: error_code::INTERNAL_ERROR,
+            message: "bad params".into(),
+            data: Some(json!([
+                {
+                    "@type": errordetails::BAD_REQUEST_TYPE,
+                    "fieldViolations": [
+                        {"field": "task.id", "description": "required"}
+                    ]
+                },
+                {
+                    "@type": errordetails::ERROR_INFO_TYPE,
+                    "reason": "INVALID_PARAMS",
+                    "domain": errordetails::PROTOCOL_DOMAIN,
+                    "metadata": {}
+                }
+            ])),
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        // ErrorInfo reason takes precedence
+        assert_eq!(a2a_err.code, error_code::INVALID_PARAMS);
+        assert!(a2a_err.message.contains("task.id: required"));
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_ignores_non_protocol_domain() {
+        let err = JsonRpcError {
+            code: error_code::INTERNAL_ERROR,
+            message: "err".into(),
+            data: Some(json!([
+                {
+                    "@type": errordetails::ERROR_INFO_TYPE,
+                    "reason": "TASK_NOT_FOUND",
+                    "domain": "other.domain.com",
+                    "metadata": {}
+                }
+            ])),
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        // Should not override code since domain doesn't match
+        assert_eq!(a2a_err.code, error_code::INTERNAL_ERROR);
+    }
+
+    #[test]
+    fn test_parse_jsonrpc_error_bad_request_empty_violations() {
+        let err = JsonRpcError {
+            code: error_code::INTERNAL_ERROR,
+            message: "invalid".into(),
+            data: Some(json!([
+                {
+                    "@type": errordetails::BAD_REQUEST_TYPE,
+                    "fieldViolations": []
+                }
+            ])),
+        };
+        let a2a_err = parse_jsonrpc_error(err);
+        assert_eq!(a2a_err.code, error_code::INVALID_PARAMS);
+        // Message should not be modified when violations are empty
+        assert_eq!(a2a_err.message, "invalid");
     }
 }

--- a/a2a-client/src/lib.rs
+++ b/a2a-client/src/lib.rs
@@ -15,6 +15,59 @@ pub use factory::A2AClientFactory;
 pub use futures::stream::BoxStream;
 pub use transport::{ServiceParams, Transport, TransportFactory};
 
+pub(crate) fn a2a_error_from_details(
+    code: i32,
+    message: String,
+    details: Vec<a2a::TypedDetail>,
+) -> a2a::A2AError {
+    use a2a::{error_code, errordetails, reason_to_error_code};
+    use serde_json::Value;
+
+    let mut code = code;
+    let mut message = message;
+
+    for detail in &details {
+        match detail.type_url.as_str() {
+            errordetails::BAD_REQUEST_TYPE => {
+                if let Some(Value::Array(violations)) = detail.value.get("fieldViolations") {
+                    let violation_strs: Vec<String> = violations
+                        .iter()
+                        .filter_map(|v| {
+                            let field = v.get("field")?.as_str()?;
+                            let desc = v.get("description")?.as_str()?;
+                            Some(format!("{field}: {desc}"))
+                        })
+                        .collect();
+                    if !violation_strs.is_empty() {
+                        message = format!("{}: {}", message, violation_strs.join("; "));
+                    }
+                }
+                if code == error_code::INTERNAL_ERROR {
+                    code = error_code::INVALID_PARAMS;
+                }
+            }
+            errordetails::ERROR_INFO_TYPE => {
+                if let Some(Value::String(domain)) = detail.value.get("domain") {
+                    if domain == errordetails::PROTOCOL_DOMAIN {
+                        if let Some(Value::String(reason)) = detail.value.get("reason") {
+                            if let Some(c) = reason_to_error_code(reason) {
+                                code = c;
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    a2a::A2AError {
+        code,
+        message,
+        details: (!details.is_empty()).then_some(details),
+    }
+}
+
 pub(crate) fn build_reqwest_client_with_root_pem(
     pem: &[u8],
 ) -> Result<reqwest::Client, a2a::A2AError> {

--- a/a2a-client/src/rest.rs
+++ b/a2a-client/src/rest.rs
@@ -7,7 +7,6 @@ use futures::stream::BoxStream;
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashMap;
 
 use crate::push_config_compat::{
     deserialize_list_task_push_notification_configs_response,
@@ -18,8 +17,6 @@ use crate::transport::{ServiceParams, Transport, TransportFactory};
 const REST_SEND_MESSAGE_PATH: &str = "/message:send";
 const REST_STREAM_MESSAGE_PATH: &str = "/message:stream";
 const REST_EXTENDED_AGENT_CARD_PATH: &str = "/extendedAgentCard";
-const REST_ERROR_INFO_TYPE_URL: &str = "type.googleapis.com/google.rpc.ErrorInfo";
-const REST_ERROR_DOMAIN: &str = "a2a-protocol.org";
 
 #[derive(Debug, Deserialize)]
 struct RestErrorEnvelope {
@@ -31,18 +28,7 @@ struct RestErrorStatus {
     message: String,
 
     #[serde(default)]
-    details: Vec<Value>,
-}
-
-#[derive(Debug, Deserialize)]
-struct RestErrorInfo {
-    #[serde(rename = "@type")]
-    type_url: String,
-    reason: String,
-    domain: String,
-
-    #[serde(default)]
-    metadata: HashMap<String, String>,
+    details: Vec<TypedDetail>,
 }
 
 /// REST (HTTP+JSON) transport implementation.
@@ -252,54 +238,11 @@ fn parse_rest_error(status: reqwest::StatusCode, body: &str) -> A2AError {
         return A2AError::internal(format!("HTTP {status}: {body}"));
     };
 
-    let mut details = HashMap::new();
-    let mut code = None;
-
-    for raw_detail in envelope.error.details {
-        if let Ok(info) = serde_json::from_value::<RestErrorInfo>(raw_detail.clone()) {
-            if info.type_url == REST_ERROR_INFO_TYPE_URL && info.domain == REST_ERROR_DOMAIN {
-                code = reason_to_error_code(&info.reason).or(code);
-                for (key, value) in info.metadata {
-                    details.insert(key, Value::String(value));
-                }
-                continue;
-            }
-        }
-
-        if let Value::Object(values) = raw_detail {
-            details.extend(values);
-        }
-    }
-
-    A2AError {
-        code: code.unwrap_or(error_code::INTERNAL_ERROR),
-        message: envelope.error.message,
-        details: (!details.is_empty()).then_some(details),
-    }
-}
-
-fn reason_to_error_code(reason: &str) -> Option<i32> {
-    match reason {
-        "TASK_NOT_FOUND" => Some(error_code::TASK_NOT_FOUND),
-        "TASK_NOT_CANCELABLE" => Some(error_code::TASK_NOT_CANCELABLE),
-        "PUSH_NOTIFICATION_NOT_SUPPORTED" => Some(error_code::PUSH_NOTIFICATION_NOT_SUPPORTED),
-        "UNSUPPORTED_OPERATION" => Some(error_code::UNSUPPORTED_OPERATION),
-        "UNSUPPORTED_CONTENT_TYPE" | "CONTENT_TYPE_NOT_SUPPORTED" => {
-            Some(error_code::CONTENT_TYPE_NOT_SUPPORTED)
-        }
-        "INVALID_AGENT_RESPONSE" => Some(error_code::INVALID_AGENT_RESPONSE),
-        "EXTENDED_AGENT_CARD_NOT_CONFIGURED" | "EXTENDED_CARD_NOT_CONFIGURED" => {
-            Some(error_code::EXTENDED_CARD_NOT_CONFIGURED)
-        }
-        "EXTENSION_SUPPORT_REQUIRED" => Some(error_code::EXTENSION_SUPPORT_REQUIRED),
-        "VERSION_NOT_SUPPORTED" => Some(error_code::VERSION_NOT_SUPPORTED),
-        "PARSE_ERROR" => Some(error_code::PARSE_ERROR),
-        "INVALID_REQUEST" => Some(error_code::INVALID_REQUEST),
-        "METHOD_NOT_FOUND" => Some(error_code::METHOD_NOT_FOUND),
-        "INVALID_PARAMS" => Some(error_code::INVALID_PARAMS),
-        "INTERNAL_ERROR" => Some(error_code::INTERNAL_ERROR),
-        _ => None,
-    }
+    crate::a2a_error_from_details(
+        error_code::INTERNAL_ERROR,
+        envelope.error.message,
+        envelope.error.details,
+    )
 }
 
 #[async_trait]
@@ -575,9 +518,9 @@ mod tests {
                 "message": "task not found: t1",
                 "details": [
                     {
-                        "@type": REST_ERROR_INFO_TYPE_URL,
+                        "@type": errordetails::ERROR_INFO_TYPE,
                         "reason": "TASK_NOT_FOUND",
-                        "domain": REST_ERROR_DOMAIN,
+                        "domain": errordetails::PROTOCOL_DOMAIN,
                         "metadata": {
                             "taskId": "t1"
                         }
@@ -595,8 +538,12 @@ mod tests {
         assert_eq!(err.code, error_code::TASK_NOT_FOUND);
         assert_eq!(err.message, "task not found: t1");
         let details = err.details.expect("expected structured details");
-        assert_eq!(details.get("taskId"), Some(&Value::String("t1".into())));
-        assert_eq!(details.get("resource"), Some(&Value::String("task".into())));
+        assert_eq!(details.len(), 2);
+        assert_eq!(details[0].type_url, errordetails::ERROR_INFO_TYPE);
+        assert_eq!(
+            details[1].value.get("resource"),
+            Some(&Value::String("task".into()))
+        );
     }
 
     #[test]
@@ -608,9 +555,9 @@ mod tests {
                 "message": "incompatible content types",
                 "details": [
                     {
-                        "@type": REST_ERROR_INFO_TYPE_URL,
+                        "@type": errordetails::ERROR_INFO_TYPE,
                         "reason": "UNSUPPORTED_CONTENT_TYPE",
-                        "domain": REST_ERROR_DOMAIN,
+                        "domain": errordetails::PROTOCOL_DOMAIN,
                         "metadata": {}
                     }
                 ]
@@ -620,6 +567,70 @@ mod tests {
 
         let err = parse_rest_error(reqwest::StatusCode::BAD_REQUEST, &body);
         assert_eq!(err.code, error_code::CONTENT_TYPE_NOT_SUPPORTED);
+    }
+
+    #[test]
+    fn test_parse_rest_error_bad_request_fallback() {
+        let body = json!({
+            "error": {
+                "code": 400,
+                "status": "INVALID_ARGUMENT",
+                "message": "invalid request parameters",
+                "details": [
+                    {
+                        "@type": errordetails::BAD_REQUEST_TYPE,
+                        "fieldViolations": [
+                            {
+                                "field": "message.parts",
+                                "description": "At least one part is required"
+                            }
+                        ]
+                    }
+                ]
+            }
+        })
+        .to_string();
+
+        let err = parse_rest_error(reqwest::StatusCode::BAD_REQUEST, &body);
+        assert_eq!(err.code, error_code::INVALID_PARAMS);
+        assert!(
+            err.message
+                .contains("message.parts: At least one part is required")
+        );
+        let details = err.details.expect("expected details");
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0].type_url, errordetails::BAD_REQUEST_TYPE);
+        let violations = details[0].value.get("fieldViolations").unwrap();
+        assert_eq!(violations[0]["field"], "message.parts");
+    }
+
+    #[test]
+    fn test_parse_rest_error_bad_request_with_error_info_uses_reason() {
+        let body = json!({
+            "error": {
+                "code": 400,
+                "status": "INVALID_ARGUMENT",
+                "message": "bad params",
+                "details": [
+                    {
+                        "@type": errordetails::BAD_REQUEST_TYPE,
+                        "fieldViolations": [
+                            {"field": "task.id", "description": "required"}
+                        ]
+                    },
+                    {
+                        "@type": errordetails::ERROR_INFO_TYPE,
+                        "reason": "INVALID_PARAMS",
+                        "domain": errordetails::PROTOCOL_DOMAIN,
+                        "metadata": {}
+                    }
+                ]
+            }
+        })
+        .to_string();
+
+        let err = parse_rest_error(reqwest::StatusCode::BAD_REQUEST, &body);
+        assert_eq!(err.code, error_code::INVALID_PARAMS);
     }
 
     #[test]

--- a/a2a-grpc/src/errors.rs
+++ b/a2a-grpc/src/errors.rs
@@ -8,11 +8,11 @@ pub fn a2a_error_to_status(err: &A2AError) -> tonic::Status {
     let code = match err.code {
         error_code::TASK_NOT_FOUND => tonic::Code::NotFound,
         error_code::TASK_NOT_CANCELABLE => tonic::Code::FailedPrecondition,
-        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED => tonic::Code::Unimplemented,
-        error_code::UNSUPPORTED_OPERATION => tonic::Code::Unimplemented,
+        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED => tonic::Code::FailedPrecondition,
+        error_code::UNSUPPORTED_OPERATION => tonic::Code::FailedPrecondition,
         error_code::CONTENT_TYPE_NOT_SUPPORTED => tonic::Code::InvalidArgument,
         error_code::INVALID_AGENT_RESPONSE => tonic::Code::Internal,
-        error_code::EXTENDED_CARD_NOT_CONFIGURED => tonic::Code::Unimplemented,
+        error_code::EXTENDED_CARD_NOT_CONFIGURED => tonic::Code::FailedPrecondition,
         error_code::EXTENSION_SUPPORT_REQUIRED => tonic::Code::FailedPrecondition,
         error_code::VERSION_NOT_SUPPORTED => tonic::Code::FailedPrecondition,
         error_code::PARSE_ERROR => tonic::Code::InvalidArgument,
@@ -31,7 +31,7 @@ pub fn status_to_a2a_error(status: &tonic::Status) -> A2AError {
     let code = match status.code() {
         tonic::Code::NotFound => error_code::TASK_NOT_FOUND,
         tonic::Code::FailedPrecondition => error_code::TASK_NOT_CANCELABLE,
-        tonic::Code::Unimplemented => error_code::UNSUPPORTED_OPERATION,
+        tonic::Code::Unimplemented => error_code::METHOD_NOT_FOUND,
         tonic::Code::InvalidArgument => error_code::INVALID_PARAMS,
         tonic::Code::Internal => error_code::INTERNAL_ERROR,
         _ => error_code::INTERNAL_ERROR,
@@ -54,11 +54,11 @@ mod tests {
             ),
             (
                 error_code::PUSH_NOTIFICATION_NOT_SUPPORTED,
-                tonic::Code::Unimplemented,
+                tonic::Code::FailedPrecondition,
             ),
             (
                 error_code::UNSUPPORTED_OPERATION,
-                tonic::Code::Unimplemented,
+                tonic::Code::FailedPrecondition,
             ),
             (
                 error_code::CONTENT_TYPE_NOT_SUPPORTED,
@@ -91,10 +91,7 @@ mod tests {
                 tonic::Code::FailedPrecondition,
                 error_code::TASK_NOT_CANCELABLE,
             ),
-            (
-                tonic::Code::Unimplemented,
-                error_code::UNSUPPORTED_OPERATION,
-            ),
+            (tonic::Code::Unimplemented, error_code::METHOD_NOT_FOUND),
             (tonic::Code::InvalidArgument, error_code::INVALID_PARAMS),
             (tonic::Code::Internal, error_code::INTERNAL_ERROR),
         ];
@@ -121,7 +118,7 @@ mod tests {
         let cases = [
             (
                 error_code::EXTENDED_CARD_NOT_CONFIGURED,
-                tonic::Code::Unimplemented,
+                tonic::Code::FailedPrecondition,
             ),
             (
                 error_code::EXTENSION_SUPPORT_REQUIRED,

--- a/a2a-server/src/rest.rs
+++ b/a2a-server/src/rest.rs
@@ -31,9 +31,6 @@ const REST_PUSH_CONFIGS_PATH: &str = "/tasks/{id}/pushNotificationConfigs";
 const REST_PUSH_CONFIGS_LEGACY_PATH: &str = "/tasks/{id}/push-configs";
 const REST_PUSH_CONFIG_PATH: &str = "/tasks/{id}/pushNotificationConfigs/{config_id}";
 const REST_PUSH_CONFIG_LEGACY_PATH: &str = "/tasks/{id}/push-configs/{config_id}";
-const REST_ERROR_INFO_TYPE_URL: &str = "type.googleapis.com/google.rpc.ErrorInfo";
-const REST_ERROR_DOMAIN: &str = "a2a-protocol.org";
-
 #[derive(Serialize)]
 struct RestErrorEnvelope {
     error: RestErrorStatus,
@@ -44,16 +41,7 @@ struct RestErrorStatus {
     code: u16,
     status: &'static str,
     message: String,
-    details: Vec<Value>,
-}
-
-#[derive(Serialize)]
-struct RestErrorInfo {
-    #[serde(rename = "@type")]
-    type_url: &'static str,
-    reason: &'static str,
-    domain: &'static str,
-    metadata: HashMap<String, String>,
+    details: Vec<TypedDetail>,
 }
 
 /// Shared state for REST handlers.
@@ -437,45 +425,46 @@ fn parse_create_push_config_request(
 }
 
 fn rest_payload_error_response(error: impl std::fmt::Display) -> axum::response::Response {
-    rest_error_response(A2AError {
-        code: error_code::PARSE_ERROR,
-        message: format!("invalid request body: {error}"),
-        details: None,
-    })
+    let violation = FieldViolation {
+        field: String::new(),
+        description: error.to_string(),
+    };
+    rest_error_response(
+        A2AError::invalid_params(format!("invalid request body: {error}"))
+            .with_details(vec![TypedDetail::bad_request(vec![violation])]),
+    )
 }
 
 fn rest_error_response(err: A2AError) -> axum::response::Response {
     let status =
         StatusCode::from_u16(err.http_status_code()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-    let reason = rest_error_reason(err.code);
+    let reason = error_reason(err.code);
     let grpc_status = rest_grpc_status(err.code);
 
     let mut metadata = HashMap::from([("timestamp".to_string(), Utc::now().to_rfc3339())]);
-    let mut extra_details = serde_json::Map::new();
+    let mut details = Vec::new();
 
-    if let Some(details) = err.details {
-        for (key, value) in details {
-            if let Some(as_string) = value.as_str() {
-                metadata.insert(key, as_string.to_string());
+    if let Some(extra) = err.details {
+        for detail in extra {
+            if detail.type_url == errordetails::ERROR_INFO_TYPE {
+                if let Some(Value::Object(meta)) = detail.value.get("metadata") {
+                    for (k, v) in meta {
+                        if let Some(s) = v.as_str() {
+                            metadata.entry(k.clone()).or_insert_with(|| s.to_string());
+                        }
+                    }
+                }
             } else {
-                extra_details.insert(key, value);
+                details.push(detail);
             }
         }
     }
 
-    let mut details = vec![
-        serde_json::to_value(RestErrorInfo {
-            type_url: REST_ERROR_INFO_TYPE_URL,
-            reason,
-            domain: REST_ERROR_DOMAIN,
-            metadata,
-        })
-        .expect("rest error info should serialize"),
-    ];
-
-    if !extra_details.is_empty() {
-        details.push(Value::Object(extra_details));
-    }
+    details.push(TypedDetail::error_info(
+        reason,
+        errordetails::PROTOCOL_DOMAIN,
+        Some(metadata),
+    ));
 
     let body = RestErrorEnvelope {
         error: RestErrorStatus {
@@ -489,34 +478,16 @@ fn rest_error_response(err: A2AError) -> axum::response::Response {
     (status, Json(body)).into_response()
 }
 
-fn rest_error_reason(code: i32) -> &'static str {
-    match code {
-        error_code::TASK_NOT_FOUND => "TASK_NOT_FOUND",
-        error_code::TASK_NOT_CANCELABLE => "TASK_NOT_CANCELABLE",
-        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED => "PUSH_NOTIFICATION_NOT_SUPPORTED",
-        error_code::UNSUPPORTED_OPERATION => "UNSUPPORTED_OPERATION",
-        error_code::CONTENT_TYPE_NOT_SUPPORTED => "UNSUPPORTED_CONTENT_TYPE",
-        error_code::INVALID_AGENT_RESPONSE => "INVALID_AGENT_RESPONSE",
-        error_code::EXTENDED_CARD_NOT_CONFIGURED => "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
-        error_code::EXTENSION_SUPPORT_REQUIRED => "EXTENSION_SUPPORT_REQUIRED",
-        error_code::VERSION_NOT_SUPPORTED => "VERSION_NOT_SUPPORTED",
-        error_code::PARSE_ERROR => "PARSE_ERROR",
-        error_code::INVALID_REQUEST => "INVALID_REQUEST",
-        error_code::METHOD_NOT_FOUND => "METHOD_NOT_FOUND",
-        error_code::INVALID_PARAMS => "INVALID_PARAMS",
-        _ => "INTERNAL_ERROR",
-    }
-}
-
 fn rest_grpc_status(code: i32) -> &'static str {
     match code {
-        error_code::TASK_NOT_FOUND | error_code::METHOD_NOT_FOUND => "NOT_FOUND",
+        error_code::TASK_NOT_FOUND => "NOT_FOUND",
+        error_code::METHOD_NOT_FOUND => "UNIMPLEMENTED",
         error_code::TASK_NOT_CANCELABLE
         | error_code::EXTENDED_CARD_NOT_CONFIGURED
-        | error_code::EXTENSION_SUPPORT_REQUIRED => "FAILED_PRECONDITION",
-        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED
+        | error_code::EXTENSION_SUPPORT_REQUIRED
+        | error_code::PUSH_NOTIFICATION_NOT_SUPPORTED
         | error_code::UNSUPPORTED_OPERATION
-        | error_code::VERSION_NOT_SUPPORTED => "UNIMPLEMENTED",
+        | error_code::VERSION_NOT_SUPPORTED => "FAILED_PRECONDITION",
         error_code::CONTENT_TYPE_NOT_SUPPORTED
         | error_code::PARSE_ERROR
         | error_code::INVALID_REQUEST
@@ -792,7 +763,76 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
 
         let resp = rest_error_response(A2AError::content_type_not_supported());
-        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_rest_error_response_merges_error_info_metadata() {
+        let existing_info = TypedDetail::error_info(
+            "TASK_NOT_FOUND",
+            errordetails::PROTOCOL_DOMAIN,
+            Some(HashMap::from([("taskId".to_string(), "t99".to_string())])),
+        );
+        let err = A2AError::task_not_found("t99").with_details(vec![existing_info]);
+        let resp = rest_error_response(err);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let details = payload["error"]["details"].as_array().unwrap();
+        // Only one ErrorInfo should be present (merged)
+        assert_eq!(details.len(), 1);
+        assert_eq!(details[0]["@type"], errordetails::ERROR_INFO_TYPE);
+        assert_eq!(details[0]["reason"], "TASK_NOT_FOUND");
+        // Merged metadata should contain both taskId and timestamp
+        assert_eq!(details[0]["metadata"]["taskId"], "t99");
+        assert!(details[0]["metadata"]["timestamp"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_rest_error_response_preserves_non_error_info_details() {
+        let bad_req = TypedDetail::bad_request(vec![FieldViolation {
+            field: "message.parts".into(),
+            description: "required".into(),
+        }]);
+        let err = A2AError::invalid_params("bad request").with_details(vec![bad_req]);
+        let resp = rest_error_response(err);
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let details = payload["error"]["details"].as_array().unwrap();
+        // BadRequest detail + auto-generated ErrorInfo
+        assert_eq!(details.len(), 2);
+        assert_eq!(details[0]["@type"], errordetails::BAD_REQUEST_TYPE);
+        assert_eq!(details[0]["fieldViolations"][0]["field"], "message.parts");
+        assert_eq!(details[1]["@type"], errordetails::ERROR_INFO_TYPE);
+        assert_eq!(details[1]["reason"], "INVALID_PARAMS");
+    }
+
+    #[tokio::test]
+    async fn test_rest_payload_error_response() {
+        let resp = rest_payload_error_response("missing field 'parts'");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            payload["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("missing field 'parts'")
+        );
+        let details = payload["error"]["details"].as_array().unwrap();
+        // BadRequest detail + ErrorInfo
+        assert_eq!(details.len(), 2);
+        assert_eq!(details[0]["@type"], errordetails::BAD_REQUEST_TYPE);
+        assert_eq!(
+            details[0]["fieldViolations"][0]["description"],
+            "missing field 'parts'"
+        );
+        assert_eq!(details[1]["@type"], errordetails::ERROR_INFO_TYPE);
+        assert_eq!(details[1]["reason"], "INVALID_PARAMS");
     }
 
     #[tokio::test]

--- a/a2a-slimrpc/src/errors.rs
+++ b/a2a-slimrpc/src/errors.rs
@@ -10,13 +10,11 @@ pub fn a2a_error_to_rpc_error(err: &A2AError) -> slim_bindings::RpcError {
         error_code::TASK_NOT_FOUND => slim_bindings::RpcError::not_found(err.message.clone()),
         error_code::TASK_NOT_CANCELABLE
         | error_code::EXTENSION_SUPPORT_REQUIRED
-        | error_code::VERSION_NOT_SUPPORTED => {
-            slim_bindings::RpcError::failed_precondition(err.message.clone())
-        }
-        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED
+        | error_code::VERSION_NOT_SUPPORTED
+        | error_code::PUSH_NOTIFICATION_NOT_SUPPORTED
         | error_code::UNSUPPORTED_OPERATION
         | error_code::EXTENDED_CARD_NOT_CONFIGURED => {
-            slim_bindings::RpcError::unimplemented(err.message.clone())
+            slim_bindings::RpcError::failed_precondition(err.message.clone())
         }
         error_code::CONTENT_TYPE_NOT_SUPPORTED
         | error_code::PARSE_ERROR
@@ -64,9 +62,12 @@ mod tests {
             (error_code::TASK_NOT_CANCELABLE, RpcCode::FailedPrecondition),
             (
                 error_code::PUSH_NOTIFICATION_NOT_SUPPORTED,
-                RpcCode::Unimplemented,
+                RpcCode::FailedPrecondition,
             ),
-            (error_code::UNSUPPORTED_OPERATION, RpcCode::Unimplemented),
+            (
+                error_code::UNSUPPORTED_OPERATION,
+                RpcCode::FailedPrecondition,
+            ),
             (
                 error_code::CONTENT_TYPE_NOT_SUPPORTED,
                 RpcCode::InvalidArgument,
@@ -111,7 +112,7 @@ mod tests {
             ),
             (
                 error_code::EXTENDED_CARD_NOT_CONFIGURED,
-                RpcCode::Unimplemented,
+                RpcCode::FailedPrecondition,
             ),
             (error_code::PARSE_ERROR, RpcCode::InvalidArgument),
             (error_code::INVALID_REQUEST, RpcCode::InvalidArgument),

--- a/a2a/src/errordetails.rs
+++ b/a2a/src/errordetails.rs
@@ -1,0 +1,199 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize, de::Deserializer, ser::Serializer};
+use serde_json::Value;
+
+pub const ERROR_INFO_TYPE: &str = "type.googleapis.com/google.rpc.ErrorInfo";
+pub const BAD_REQUEST_TYPE: &str = "type.googleapis.com/google.rpc.BadRequest";
+pub const STRUCT_TYPE: &str = "type.googleapis.com/google.protobuf.Struct";
+pub const PROTOCOL_DOMAIN: &str = "a2a-protocol.org";
+
+/// A field-level validation error, matching `google.rpc.BadRequest.FieldViolation`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FieldViolation {
+    pub field: String,
+    pub description: String,
+}
+
+/// A typed error detail object using ProtoJSON `Any` representation.
+///
+/// Each detail object carries a `@type` URL identifying its schema and
+/// a map of additional fields. When serialized to JSON, `@type` is
+/// flattened into the object alongside the value fields.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TypedDetail {
+    pub type_url: String,
+    pub value: HashMap<String, Value>,
+}
+
+impl TypedDetail {
+    pub fn new(type_url: impl Into<String>, value: HashMap<String, Value>) -> Self {
+        Self {
+            type_url: type_url.into(),
+            value,
+        }
+    }
+
+    /// Create a `google.rpc.ErrorInfo` detail.
+    pub fn error_info(
+        reason: impl Into<String>,
+        domain: impl Into<String>,
+        metadata: Option<HashMap<String, String>>,
+    ) -> Self {
+        let mut value = HashMap::new();
+        value.insert("reason".to_string(), Value::String(reason.into()));
+        value.insert("domain".to_string(), Value::String(domain.into()));
+        if let Some(meta) = metadata {
+            let meta_obj: serde_json::Map<String, Value> = meta
+                .into_iter()
+                .map(|(k, v)| (k, Value::String(v)))
+                .collect();
+            value.insert("metadata".to_string(), Value::Object(meta_obj));
+        }
+        Self {
+            type_url: ERROR_INFO_TYPE.to_string(),
+            value,
+        }
+    }
+
+    /// Create a `google.rpc.BadRequest` detail with field violations.
+    pub fn bad_request(field_violations: Vec<FieldViolation>) -> Self {
+        let violations: Vec<Value> = field_violations
+            .into_iter()
+            .map(|fv| serde_json::to_value(fv).unwrap_or_default())
+            .collect();
+        let mut value = HashMap::new();
+        value.insert("fieldViolations".to_string(), Value::Array(violations));
+        Self {
+            type_url: BAD_REQUEST_TYPE.to_string(),
+            value,
+        }
+    }
+
+    /// Create a typed detail from a struct (arbitrary map).
+    pub fn from_struct(fields: HashMap<String, Value>) -> Self {
+        Self {
+            type_url: STRUCT_TYPE.to_string(),
+            value: fields,
+        }
+    }
+}
+
+impl Serialize for TypedDetail {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.value.len() + 1))?;
+        map.serialize_entry("@type", &self.type_url)?;
+        for (k, v) in &self.value {
+            map.serialize_entry(k, v)?;
+        }
+        map.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for TypedDetail {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let mut map: HashMap<String, Value> = HashMap::deserialize(deserializer)?;
+        let type_url = map
+            .remove("@type")
+            .and_then(|v| v.as_str().map(String::from))
+            .unwrap_or_else(|| STRUCT_TYPE.to_string());
+        Ok(Self {
+            type_url,
+            value: map,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_typed_detail() {
+        let detail = TypedDetail::error_info("TASK_NOT_FOUND", PROTOCOL_DOMAIN, None);
+        let json = serde_json::to_value(&detail).unwrap();
+        assert_eq!(json["@type"], ERROR_INFO_TYPE);
+        assert_eq!(json["reason"], "TASK_NOT_FOUND");
+        assert_eq!(json["domain"], PROTOCOL_DOMAIN);
+    }
+
+    #[test]
+    fn test_deserialize_typed_detail() {
+        let json = serde_json::json!({
+            "@type": ERROR_INFO_TYPE,
+            "reason": "TASK_NOT_FOUND",
+            "domain": PROTOCOL_DOMAIN,
+            "metadata": {"taskId": "t1"}
+        });
+        let detail: TypedDetail = serde_json::from_value(json).unwrap();
+        assert_eq!(detail.type_url, ERROR_INFO_TYPE);
+        assert_eq!(detail.value["reason"], "TASK_NOT_FOUND");
+        assert_eq!(detail.value["domain"], PROTOCOL_DOMAIN);
+        assert_eq!(detail.value["metadata"]["taskId"], "t1");
+    }
+
+    #[test]
+    fn test_deserialize_without_type_defaults_to_struct() {
+        let json = serde_json::json!({"resource": "task"});
+        let detail: TypedDetail = serde_json::from_value(json).unwrap();
+        assert_eq!(detail.type_url, STRUCT_TYPE);
+        assert_eq!(detail.value["resource"], "task");
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let meta = HashMap::from([("taskId".to_string(), "t1".to_string())]);
+        let detail = TypedDetail::error_info("TASK_NOT_FOUND", PROTOCOL_DOMAIN, Some(meta));
+        let serialized = serde_json::to_value(&detail).unwrap();
+        let deserialized: TypedDetail = serde_json::from_value(serialized).unwrap();
+        assert_eq!(detail, deserialized);
+    }
+
+    #[test]
+    fn test_bad_request() {
+        let violations = vec![
+            FieldViolation {
+                field: "message.parts".into(),
+                description: "At least one part is required".into(),
+            },
+            FieldViolation {
+                field: "message.role".into(),
+                description: "Role must be 'user' or 'agent'".into(),
+            },
+        ];
+        let detail = TypedDetail::bad_request(violations);
+        assert_eq!(detail.type_url, BAD_REQUEST_TYPE);
+
+        let json = serde_json::to_value(&detail).unwrap();
+        assert_eq!(json["@type"], BAD_REQUEST_TYPE);
+        let fv = json["fieldViolations"].as_array().unwrap();
+        assert_eq!(fv.len(), 2);
+        assert_eq!(fv[0]["field"], "message.parts");
+        assert_eq!(fv[0]["description"], "At least one part is required");
+        assert_eq!(fv[1]["field"], "message.role");
+    }
+
+    #[test]
+    fn test_bad_request_round_trip() {
+        let violations = vec![FieldViolation {
+            field: "task.id".into(),
+            description: "Must not be empty".into(),
+        }];
+        let detail = TypedDetail::bad_request(violations);
+        let serialized = serde_json::to_value(&detail).unwrap();
+        let deserialized: TypedDetail = serde_json::from_value(serialized).unwrap();
+        assert_eq!(detail, deserialized);
+    }
+
+    #[test]
+    fn test_from_struct() {
+        let mut fields = HashMap::new();
+        fields.insert("key".to_string(), Value::String("val".to_string()));
+        let detail = TypedDetail::from_struct(fields.clone());
+        assert_eq!(detail.type_url, STRUCT_TYPE);
+        assert_eq!(detail.value, fields);
+    }
+}

--- a/a2a/src/errors.rs
+++ b/a2a/src/errors.rs
@@ -1,7 +1,11 @@
 // Copyright AGNTCY Contributors (https://github.com/agntcy)
 // SPDX-License-Identifier: Apache-2.0
-use serde_json::Value;
 use std::collections::HashMap;
+
+use chrono::Utc;
+use serde_json::Value;
+
+use crate::errordetails::{self, TypedDetail};
 
 /// A2A-specific error codes (JSON-RPC).
 pub mod error_code {
@@ -24,13 +28,58 @@ pub mod error_code {
     pub const INTERNAL_ERROR: i32 = -32603;
 }
 
+/// Returns the reason string for an error code.
+pub fn error_reason(code: i32) -> &'static str {
+    match code {
+        error_code::TASK_NOT_FOUND => "TASK_NOT_FOUND",
+        error_code::TASK_NOT_CANCELABLE => "TASK_NOT_CANCELABLE",
+        error_code::PUSH_NOTIFICATION_NOT_SUPPORTED => "PUSH_NOTIFICATION_NOT_SUPPORTED",
+        error_code::UNSUPPORTED_OPERATION => "UNSUPPORTED_OPERATION",
+        error_code::CONTENT_TYPE_NOT_SUPPORTED => "CONTENT_TYPE_NOT_SUPPORTED",
+        error_code::INVALID_AGENT_RESPONSE => "INVALID_AGENT_RESPONSE",
+        error_code::EXTENDED_CARD_NOT_CONFIGURED => "EXTENDED_AGENT_CARD_NOT_CONFIGURED",
+        error_code::EXTENSION_SUPPORT_REQUIRED => "EXTENSION_SUPPORT_REQUIRED",
+        error_code::VERSION_NOT_SUPPORTED => "VERSION_NOT_SUPPORTED",
+        error_code::PARSE_ERROR => "PARSE_ERROR",
+        error_code::INVALID_REQUEST => "INVALID_REQUEST",
+        error_code::METHOD_NOT_FOUND => "METHOD_NOT_FOUND",
+        error_code::INVALID_PARAMS => "INVALID_PARAMS",
+        _ => "INTERNAL_ERROR",
+    }
+}
+
+/// Returns the error code for a reason string, or `None` if unrecognized.
+pub fn reason_to_error_code(reason: &str) -> Option<i32> {
+    match reason {
+        "TASK_NOT_FOUND" => Some(error_code::TASK_NOT_FOUND),
+        "TASK_NOT_CANCELABLE" => Some(error_code::TASK_NOT_CANCELABLE),
+        "PUSH_NOTIFICATION_NOT_SUPPORTED" => Some(error_code::PUSH_NOTIFICATION_NOT_SUPPORTED),
+        "UNSUPPORTED_OPERATION" => Some(error_code::UNSUPPORTED_OPERATION),
+        "UNSUPPORTED_CONTENT_TYPE" | "CONTENT_TYPE_NOT_SUPPORTED" => {
+            Some(error_code::CONTENT_TYPE_NOT_SUPPORTED)
+        }
+        "INVALID_AGENT_RESPONSE" => Some(error_code::INVALID_AGENT_RESPONSE),
+        "EXTENDED_AGENT_CARD_NOT_CONFIGURED" | "EXTENDED_CARD_NOT_CONFIGURED" => {
+            Some(error_code::EXTENDED_CARD_NOT_CONFIGURED)
+        }
+        "EXTENSION_SUPPORT_REQUIRED" => Some(error_code::EXTENSION_SUPPORT_REQUIRED),
+        "VERSION_NOT_SUPPORTED" => Some(error_code::VERSION_NOT_SUPPORTED),
+        "PARSE_ERROR" => Some(error_code::PARSE_ERROR),
+        "INVALID_REQUEST" => Some(error_code::INVALID_REQUEST),
+        "METHOD_NOT_FOUND" => Some(error_code::METHOD_NOT_FOUND),
+        "INVALID_PARAMS" => Some(error_code::INVALID_PARAMS),
+        "INTERNAL_ERROR" => Some(error_code::INTERNAL_ERROR),
+        _ => None,
+    }
+}
+
 /// An A2A protocol error.
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("{message}")]
 pub struct A2AError {
     pub code: i32,
     pub message: String,
-    pub details: Option<HashMap<String, Value>>,
+    pub details: Option<Vec<TypedDetail>>,
 }
 
 impl A2AError {
@@ -42,7 +91,7 @@ impl A2AError {
         }
     }
 
-    pub fn with_details(mut self, details: HashMap<String, Value>) -> Self {
+    pub fn with_details(mut self, details: Vec<TypedDetail>) -> Self {
         self.details = Some(details);
         self
     }
@@ -119,14 +168,14 @@ impl A2AError {
     pub fn http_status_code(&self) -> u16 {
         match self.code {
             error_code::TASK_NOT_FOUND => 404,
-            error_code::TASK_NOT_CANCELABLE => 409,
+            error_code::TASK_NOT_CANCELABLE => 400,
             error_code::PUSH_NOTIFICATION_NOT_SUPPORTED => 400,
             error_code::UNSUPPORTED_OPERATION => 400,
-            error_code::CONTENT_TYPE_NOT_SUPPORTED => 415,
+            error_code::CONTENT_TYPE_NOT_SUPPORTED => 400,
             error_code::VERSION_NOT_SUPPORTED => 400,
             error_code::PARSE_ERROR => 400,
             error_code::INVALID_REQUEST => 400,
-            error_code::METHOD_NOT_FOUND => 404,
+            error_code::METHOD_NOT_FOUND => 501,
             error_code::INVALID_PARAMS => 400,
             error_code::INTERNAL_ERROR => 500,
             _ => 500,
@@ -134,14 +183,49 @@ impl A2AError {
     }
 
     /// Convert to a JSON-RPC error object.
+    ///
+    /// The `data` field is always populated with an array of typed detail
+    /// objects. An `ErrorInfo` detail (with reason, domain, and timestamp)
+    /// is always appended as the last element, matching the Go SDK behavior.
     pub fn to_jsonrpc_error(&self) -> crate::JsonRpcError {
+        let reason = error_reason(self.code);
+        let metadata = HashMap::from([("timestamp".to_string(), Utc::now().to_rfc3339())]);
+
+        let mut data: Vec<Value> = self
+            .details
+            .as_ref()
+            .map(|d| {
+                d.iter()
+                    .filter(|detail| detail.type_url != errordetails::ERROR_INFO_TYPE)
+                    .map(|detail| serde_json::to_value(detail).unwrap_or_default())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut error_info =
+            TypedDetail::error_info(reason, errordetails::PROTOCOL_DOMAIN, Some(metadata));
+
+        if let Some(details) = &self.details {
+            if let Some(existing) = details
+                .iter()
+                .find(|d| d.type_url == errordetails::ERROR_INFO_TYPE)
+            {
+                if let Some(Value::Object(meta)) = existing.value.get("metadata") {
+                    if let Some(Value::Object(info_meta)) = error_info.value.get_mut("metadata") {
+                        for (k, v) in meta {
+                            info_meta.entry(k.clone()).or_insert_with(|| v.clone());
+                        }
+                    }
+                }
+            }
+        }
+
+        data.push(serde_json::to_value(&error_info).unwrap_or_default());
+
         crate::JsonRpcError {
             code: self.code,
             message: self.message.clone(),
-            data: self
-                .details
-                .as_ref()
-                .map(|d| serde_json::to_value(d).unwrap_or_default()),
+            data: Some(Value::Array(data)),
         }
     }
 }
@@ -199,12 +283,12 @@ mod tests {
     #[test]
     fn test_http_status_codes() {
         assert_eq!(A2AError::task_not_found("x").http_status_code(), 404);
-        assert_eq!(A2AError::task_not_cancelable("x").http_status_code(), 409);
+        assert_eq!(A2AError::task_not_cancelable("x").http_status_code(), 400);
         assert_eq!(A2AError::internal("x").http_status_code(), 500);
         assert_eq!(A2AError::invalid_params("x").http_status_code(), 400);
         assert_eq!(
             A2AError::content_type_not_supported().http_status_code(),
-            415
+            400
         );
         assert_eq!(A2AError::new(9999, "unknown").http_status_code(), 500);
     }
@@ -227,7 +311,7 @@ mod tests {
         assert_eq!(A2AError::invalid_request("bad").http_status_code(), 400);
         assert_eq!(
             A2AError::method_not_found("missing").http_status_code(),
-            404
+            501
         );
     }
 
@@ -237,18 +321,118 @@ mod tests {
         let rpc = e.to_jsonrpc_error();
         assert_eq!(rpc.code, error_code::TASK_NOT_FOUND);
         assert!(rpc.message.contains("t1"));
-        assert!(rpc.data.is_none());
+        let data = rpc.data.expect("data should always be present");
+        let arr = data.as_array().expect("data should be an array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["@type"], errordetails::ERROR_INFO_TYPE);
+        assert_eq!(arr[0]["reason"], "TASK_NOT_FOUND");
+        assert_eq!(arr[0]["domain"], errordetails::PROTOCOL_DOMAIN);
+        assert!(arr[0]["metadata"]["timestamp"].is_string());
     }
 
     #[test]
     fn test_with_details() {
-        let mut details = HashMap::new();
-        details.insert("key".to_string(), Value::String("val".to_string()));
-        let e = A2AError::internal("err").with_details(details.clone());
-        assert_eq!(e.details.as_ref().unwrap(), &details);
+        use std::collections::HashMap;
+        let struct_detail = TypedDetail::from_struct(HashMap::from([(
+            "key".to_string(),
+            Value::String("val".to_string()),
+        )]));
+        let e = A2AError::internal("err").with_details(vec![struct_detail]);
 
         let rpc = e.to_jsonrpc_error();
-        assert!(rpc.data.is_some());
+        let data = rpc.data.expect("data should always be present");
+        let arr = data.as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["key"], "val");
+        assert_eq!(arr[1]["@type"], errordetails::ERROR_INFO_TYPE);
+        assert_eq!(arr[1]["reason"], "INTERNAL_ERROR");
+    }
+
+    #[test]
+    fn test_to_jsonrpc_error_merges_existing_error_info_metadata() {
+        let existing_info = TypedDetail::error_info(
+            "TASK_NOT_FOUND",
+            errordetails::PROTOCOL_DOMAIN,
+            Some(HashMap::from([("taskId".to_string(), "t1".to_string())])),
+        );
+        let e = A2AError::task_not_found("t1").with_details(vec![existing_info]);
+        let rpc = e.to_jsonrpc_error();
+        let data = rpc.data.unwrap();
+        let arr = data.as_array().unwrap();
+        // Existing ErrorInfo is filtered; merged into auto-generated one
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["@type"], errordetails::ERROR_INFO_TYPE);
+        assert_eq!(arr[0]["metadata"]["taskId"], "t1");
+        assert!(arr[0]["metadata"]["timestamp"].is_string());
+    }
+
+    #[test]
+    fn test_reason_to_error_code() {
+        assert_eq!(
+            reason_to_error_code("TASK_NOT_FOUND"),
+            Some(error_code::TASK_NOT_FOUND)
+        );
+        assert_eq!(
+            reason_to_error_code("TASK_NOT_CANCELABLE"),
+            Some(error_code::TASK_NOT_CANCELABLE)
+        );
+        assert_eq!(
+            reason_to_error_code("PUSH_NOTIFICATION_NOT_SUPPORTED"),
+            Some(error_code::PUSH_NOTIFICATION_NOT_SUPPORTED)
+        );
+        assert_eq!(
+            reason_to_error_code("UNSUPPORTED_OPERATION"),
+            Some(error_code::UNSUPPORTED_OPERATION)
+        );
+        assert_eq!(
+            reason_to_error_code("CONTENT_TYPE_NOT_SUPPORTED"),
+            Some(error_code::CONTENT_TYPE_NOT_SUPPORTED)
+        );
+        assert_eq!(
+            reason_to_error_code("UNSUPPORTED_CONTENT_TYPE"),
+            Some(error_code::CONTENT_TYPE_NOT_SUPPORTED)
+        );
+        assert_eq!(
+            reason_to_error_code("INVALID_AGENT_RESPONSE"),
+            Some(error_code::INVALID_AGENT_RESPONSE)
+        );
+        assert_eq!(
+            reason_to_error_code("EXTENDED_AGENT_CARD_NOT_CONFIGURED"),
+            Some(error_code::EXTENDED_CARD_NOT_CONFIGURED)
+        );
+        assert_eq!(
+            reason_to_error_code("EXTENDED_CARD_NOT_CONFIGURED"),
+            Some(error_code::EXTENDED_CARD_NOT_CONFIGURED)
+        );
+        assert_eq!(
+            reason_to_error_code("EXTENSION_SUPPORT_REQUIRED"),
+            Some(error_code::EXTENSION_SUPPORT_REQUIRED)
+        );
+        assert_eq!(
+            reason_to_error_code("VERSION_NOT_SUPPORTED"),
+            Some(error_code::VERSION_NOT_SUPPORTED)
+        );
+        assert_eq!(
+            reason_to_error_code("PARSE_ERROR"),
+            Some(error_code::PARSE_ERROR)
+        );
+        assert_eq!(
+            reason_to_error_code("INVALID_REQUEST"),
+            Some(error_code::INVALID_REQUEST)
+        );
+        assert_eq!(
+            reason_to_error_code("METHOD_NOT_FOUND"),
+            Some(error_code::METHOD_NOT_FOUND)
+        );
+        assert_eq!(
+            reason_to_error_code("INVALID_PARAMS"),
+            Some(error_code::INVALID_PARAMS)
+        );
+        assert_eq!(
+            reason_to_error_code("INTERNAL_ERROR"),
+            Some(error_code::INTERNAL_ERROR)
+        );
+        assert_eq!(reason_to_error_code("UNKNOWN_REASON"), None);
     }
 
     #[test]

--- a/a2a/src/lib.rs
+++ b/a2a/src/lib.rs
@@ -3,12 +3,14 @@
 #![doc = include_str!("../README.md")]
 
 pub mod agent_card;
+pub mod errordetails;
 pub mod errors;
 pub mod event;
 pub mod jsonrpc;
 pub mod types;
 
 pub use agent_card::*;
+pub use errordetails::*;
 pub use errors::*;
 pub use event::*;
 pub use jsonrpc::*;


### PR DESCRIPTION
Update gRPC/HTTP/REST error mappings to match the corrected google.rpc.Code-based table and change A2AError.details from HashMap<String, Value> to Vec<Value> to match the spec's array-of-typed-objects
format for JSON-RPC error data.

gRPC:
PUSH_NOTIFICATION_NOT_SUPPORTED → FailedPrecondition (was Unimplemented)
UNSUPPORTED_OPERATION → FailedPrecondition (was Unimplemented)
EXTENDED_CARD_NOT_CONFIGURED → FailedPrecondition (was Unimplemented)

HTTP:
TASK_NOT_CANCELABLE → 400 (was 409),
CONTENT_TYPE_NOT_SUPPORTED → 400 (was 415).

Ref: https://github.com/a2aproject/A2A/commit/757f0ec

Fixes: #57 