### PR TITLE
fix: allow disabling TLS in a2a-grpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ rust-version = "1.85"
 [workspace.dependencies]
 # Internal crates
 a2a = { package = "a2a-lf", path = "a2a", version = "0.2.4" }
-a2a-client = { package = "a2a-client-lf", path = "a2a-client", version = "0.1.14" }
-a2a-server = { package = "a2a-server-lf", path = "a2a-server", version = "0.2.7" }
+a2a-client = { package = "a2a-client-lf", path = "a2a-client", version = "0.1.14", default-features = false }
+a2a-server = { package = "a2a-server-lf", path = "a2a-server", version = "0.2.7", default-features = false }
 a2a-pb = { package = "a2a-pb", path = "a2a-pb", version = "0.1.7" }
 a2a-grpc = { package = "a2a-grpc", path = "a2a-grpc", version = "0.2.0" }
 a2a-slimrpc = { package = "a2a-slimrpc", path = "a2a-slimrpc", version = "0.1.9" }

--- a/a2a-client/src/jsonrpc.rs
+++ b/a2a-client/src/jsonrpc.rs
@@ -443,6 +443,7 @@ impl JsonRpcTransportFactory {
         }
     }
 
+    #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
     pub fn with_root_certificates_pem(pem: &[u8]) -> Result<Self, A2AError> {
         Ok(Self {
             client: crate::build_reqwest_client_with_root_pem(pem)?,

--- a/a2a-client/src/lib.rs
+++ b/a2a-client/src/lib.rs
@@ -15,6 +15,7 @@ pub use factory::A2AClientFactory;
 pub use futures::stream::BoxStream;
 pub use transport::{ServiceParams, Transport, TransportFactory};
 
+#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
 pub(crate) fn build_reqwest_client_with_root_pem(
     pem: &[u8],
 ) -> Result<reqwest::Client, a2a::A2AError> {

--- a/a2a-client/src/rest.rs
+++ b/a2a-client/src/rest.rs
@@ -477,6 +477,7 @@ impl RestTransportFactory {
         }
     }
 
+    #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
     pub fn with_root_certificates_pem(pem: &[u8]) -> Result<Self, A2AError> {
         Ok(Self {
             client: crate::build_reqwest_client_with_root_pem(pem)?,

--- a/a2a-grpc/Cargo.toml
+++ b/a2a-grpc/Cargo.toml
@@ -13,8 +13,8 @@ name = "a2a_grpc"
 
 [dependencies]
 a2a = { workspace = true }
-a2a-client = { workspace = true }
-a2a-server = { workspace = true }
+a2a-client = { workspace = true, default-features = false }
+a2a-server = { workspace = true, default-features = false }
 a2a-pb = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
@@ -32,5 +32,7 @@ rcgen = { workspace = true }
 rustls-pemfile = { workspace = true }
 
 [features]
-default = []
-rustls = ["dep:tonic-tls", "dep:tokio-rustls"]
+default = ["rustls-tls"]
+native-tls = ["a2a-client/native-tls", "a2a-server/native-tls"]
+rustls-tls = ["a2a-client/rustls-tls", "a2a-server/rustls-tls"]
+rustls = ["dep:tonic-tls", "dep:tokio-rustls", "rustls-tls"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,7 +26,7 @@ path = "src/helloworld_tls/client.rs"
 
 [dependencies]
 a2a = { workspace = true }
-a2a-client = { workspace = true }
+a2a-client = { workspace = true, features = ["rustls-tls"] }
 a2a-grpc = { workspace = true, features = ["rustls"] }
 a2a-pb = { workspace = true }
 a2a-server = { workspace = true, features = ["rustls"] }
@@ -35,7 +35,7 @@ tokio-stream = { workspace = true, features = ["net"] }
 tokio-rustls = { workspace = true }
 tonic-tls = { workspace = true, features = ["rustls"] }
 async-trait = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls-webpki-roots-no-provider"] }
 futures = { workspace = true }
 axum = { workspace = true }
 tonic = { workspace = true }


### PR DESCRIPTION
`a2a-grpc` depends on `a2a-client-lf` and `a2a-server-lf` with
default features enabled, which unconditionally activates
rustls-tls-webpki-roots-no-provider on reqwest.

This forces all downstream consumers to install a rustls crypto
provider at runtime, even when only using plain HTTP.

Fixes: #59 