### PR TITLE
feat: add websocket transport binding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.24.0",
  "tracing",
  "uuid",
 ]
@@ -733,6 +734,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -751,8 +753,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -895,6 +899,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1325,6 +1335,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
+ "tokio-tungstenite 0.24.0",
  "tonic",
  "tonic-tls",
  "tracing",
@@ -4099,6 +4110,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4363,6 +4398,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4570,6 +4639,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ async-trait = "0.1"
 pin-project-lite = "0.2"
 
 # HTTP
-axum = { version = "0.8", features = ["macros"] }
+axum = { version = "0.8", features = ["macros", "ws"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "charset", "http2", "system-proxy"] }
 tower = { version = "0.5", features = ["util"] }
 tower-http = { version = "0.6", features = ["cors"] }
@@ -73,3 +73,4 @@ semver = "1"
 tracing = "0.1"
 auto_impl = "1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio-tungstenite = "0.24"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The workspace supports:
 - REST / HTTP+JSON
 - gRPC via `tonic`
 - SLIMRPC via `slim_bindings`
+- WebSocket for bidirectional JSON-RPC-style sessions
 - Server-Sent Events for streaming responses
 - Protobuf-based interop with other SDKs and runtimes
 
@@ -40,10 +41,29 @@ The workspace supports:
 | HTTP+JSON / REST | `a2a-client` | `a2a-server` |
 | gRPC | `a2a-grpc` | `a2a-grpc` |
 | SLIMRPC | `a2a-slimrpc` | `a2a-slimrpc` |
+| WebSocket | `a2a-client` | `a2a-server` |
 
 The gRPC support uses the schema in `a2a-pb/proto/a2a.proto`. The REST and
 JSON-RPC bindings are intended to stay wire-compatible with other A2A SDKs,
 including Go and C# implementations.
+
+### WebSocket binding
+
+Agents advertise WebSocket support with the `WEBSOCKET` protocol binding and a
+`ws://` or `wss://` interface URL. The client factory registers WebSocket by
+default, while preserving JSON-RPC and HTTP+JSON ahead of WebSocket in the
+default preference order unless callers override `preferred_bindings`.
+
+Each WebSocket text frame contains one JSON object. Client requests use the
+same A2A JSON-RPC method names with a string `id`, optional `params`, and
+optional per-message `serviceParams`. Server responses correlate on the same
+`id` and contain either `result`, `error`, `streamEvent`, `streamError`, or
+`streamEnd`. Streaming operations send zero or more `streamEvent` frames,
+followed by either `streamEnd` or `streamError`.
+
+Connection headers are converted into service parameters during WebSocket
+upgrade. Per-message `serviceParams` are merged into those connection-level
+parameters before dispatching through the server `RequestHandler`.
 
 ## Requirements
 
@@ -143,7 +163,7 @@ a2a-slimrpc = { package = "a2a-slimrpc", git = "https://github.com/a2aproject/a2
 Typical usage is:
 
 - `a2a` for protocol types and serde models
-- `a2a-client` for clients that negotiate REST or JSON-RPC from an agent card
+- `a2a-client` for clients that negotiate REST, JSON-RPC, or WebSocket from an agent card
 - `a2a-server` for agent implementations on `axum`
 - `a2a-grpc` when you need gRPC transport support
 - `a2a-slimrpc` when you need SLIMRPC transport support

--- a/a2a-client/Cargo.toml
+++ b/a2a-client/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { workspace = true }
 semver = { workspace = true }
 pin-project-lite = { workspace = true }
 rustls = { workspace = true, optional = true, features = ["aws-lc-rs"] }
+tokio-tungstenite = { workspace = true }
 
 [dev-dependencies]
 rcgen = { workspace = true }

--- a/a2a-client/src/factory.rs
+++ b/a2a-client/src/factory.rs
@@ -9,6 +9,7 @@ use crate::jsonrpc::JsonRpcTransportFactory;
 use crate::middleware::CallInterceptor;
 use crate::rest::RestTransportFactory;
 use crate::transport::TransportFactory;
+use crate::websocket::WebSocketTransportFactory;
 
 /// Key for looking up transport factories.
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -178,6 +179,11 @@ impl A2AClientFactoryBuilder {
             self.factories
                 .entry(rest_key)
                 .or_insert_with(|| Arc::new(RestTransportFactory::new(None)));
+
+            let ws_key = TransportKey::from_protocol(TRANSPORT_PROTOCOL_WEBSOCKET, VERSION);
+            self.factories
+                .entry(ws_key)
+                .or_insert_with(|| Arc::new(WebSocketTransportFactory::new()));
         }
 
         A2AClientFactory {
@@ -191,6 +197,8 @@ impl A2AClientFactoryBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use futures::stream;
 
     #[test]
     fn test_transport_key_from_interface() {
@@ -217,7 +225,7 @@ mod tests {
     #[test]
     fn test_builder_defaults() {
         let factory = A2AClientFactory::builder().build();
-        assert_eq!(factory.factories.len(), 2); // jsonrpc + rest
+        assert_eq!(factory.factories.len(), 3); // jsonrpc + rest + websocket
         assert_eq!(factory.preferred_bindings.len(), 2);
     }
 
@@ -265,5 +273,178 @@ mod tests {
         };
         let result = factory.create_from_card(&card).await;
         assert!(result.is_err());
+    }
+
+    struct DummyTransport;
+
+    #[async_trait]
+    impl crate::Transport for DummyTransport {
+        async fn send_message(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &SendMessageRequest,
+        ) -> Result<SendMessageResponse, A2AError> {
+            unimplemented!()
+        }
+
+        async fn send_streaming_message(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &SendMessageRequest,
+        ) -> Result<crate::BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            Ok(Box::pin(stream::empty()))
+        }
+
+        async fn get_task(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &GetTaskRequest,
+        ) -> Result<Task, A2AError> {
+            unimplemented!()
+        }
+
+        async fn list_tasks(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &ListTasksRequest,
+        ) -> Result<ListTasksResponse, A2AError> {
+            unimplemented!()
+        }
+
+        async fn cancel_task(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &CancelTaskRequest,
+        ) -> Result<Task, A2AError> {
+            unimplemented!()
+        }
+
+        async fn subscribe_to_task(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &SubscribeToTaskRequest,
+        ) -> Result<crate::BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            Ok(Box::pin(stream::empty()))
+        }
+
+        async fn create_push_config(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &CreateTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            unimplemented!()
+        }
+
+        async fn get_push_config(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &GetTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            unimplemented!()
+        }
+
+        async fn list_push_configs(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &ListTaskPushNotificationConfigsRequest,
+        ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+            unimplemented!()
+        }
+
+        async fn delete_push_config(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &DeleteTaskPushNotificationConfigRequest,
+        ) -> Result<(), A2AError> {
+            unimplemented!()
+        }
+
+        async fn get_extended_agent_card(
+            &self,
+            _params: &crate::ServiceParams,
+            _req: &GetExtendedAgentCardRequest,
+        ) -> Result<AgentCard, A2AError> {
+            unimplemented!()
+        }
+
+        async fn destroy(&self) -> Result<(), A2AError> {
+            Ok(())
+        }
+    }
+
+    struct DummyFactory {
+        protocol: &'static str,
+    }
+
+    #[async_trait]
+    impl TransportFactory for DummyFactory {
+        fn protocol(&self) -> &str {
+            self.protocol
+        }
+
+        async fn create(
+            &self,
+            _card: &AgentCard,
+            _iface: &AgentInterface,
+        ) -> Result<Box<dyn crate::Transport>, A2AError> {
+            Ok(Box::new(DummyTransport))
+        }
+    }
+
+    fn card_with_interfaces(supported_interfaces: Vec<AgentInterface>) -> AgentCard {
+        AgentCard {
+            name: "test".into(),
+            description: "test agent".into(),
+            version: "1.0".into(),
+            supported_interfaces,
+            capabilities: AgentCapabilities::default(),
+            default_input_modes: vec!["text".into()],
+            default_output_modes: vec!["text".into()],
+            skills: vec![],
+            provider: None,
+            documentation_url: None,
+            icon_url: None,
+            security_schemes: None,
+            security_requirements: None,
+            signatures: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_from_card_selects_websocket_when_only_match() {
+        let factory = A2AClientFactory::builder()
+            .no_defaults()
+            .register(Arc::new(DummyFactory {
+                protocol: TRANSPORT_PROTOCOL_WEBSOCKET,
+            }))
+            .build();
+        let card = card_with_interfaces(vec![AgentInterface::new(
+            "ws://localhost/ws",
+            TRANSPORT_PROTOCOL_WEBSOCKET,
+        )]);
+
+        let result = factory.create_from_card(&card).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_create_from_card_honors_websocket_preference() {
+        let factory = A2AClientFactory::builder()
+            .no_defaults()
+            .register(Arc::new(DummyFactory {
+                protocol: TRANSPORT_PROTOCOL_JSONRPC,
+            }))
+            .register(Arc::new(DummyFactory {
+                protocol: TRANSPORT_PROTOCOL_WEBSOCKET,
+            }))
+            .preferred_bindings(vec![TRANSPORT_PROTOCOL_WEBSOCKET.to_string()])
+            .build();
+        let card = card_with_interfaces(vec![
+            AgentInterface::new("http://localhost/rpc", TRANSPORT_PROTOCOL_JSONRPC),
+            AgentInterface::new("ws://localhost/ws", TRANSPORT_PROTOCOL_WEBSOCKET),
+        ]);
+
+        let result = factory.create_from_card(&card).await;
+        assert!(result.is_ok());
     }
 }

--- a/a2a-client/src/lib.rs
+++ b/a2a-client/src/lib.rs
@@ -9,6 +9,7 @@ pub mod middleware;
 mod push_config_compat;
 pub mod rest;
 pub mod transport;
+pub mod websocket;
 
 pub use client::A2AClient;
 pub use factory::A2AClientFactory;

--- a/a2a-client/src/websocket.rs
+++ b/a2a-client/src/websocket.rs
@@ -1,0 +1,819 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use a2a::jsonrpc::methods;
+use a2a::websocket::{WebSocketRequestEnvelope, WebSocketResponseEnvelope};
+use a2a::*;
+use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::{SinkExt, StreamExt};
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+use crate::push_config_compat::{
+    deserialize_list_task_push_notification_configs_response,
+    deserialize_task_push_notification_config,
+    serialize_create_task_push_notification_config_request,
+};
+use crate::transport::{ServiceParams, Transport, TransportFactory};
+
+type UnaryResultTx = oneshot::Sender<Result<serde_json::Value, A2AError>>;
+type StreamResultTx = mpsc::UnboundedSender<Result<StreamResponse, A2AError>>;
+
+struct WebSocketConnection {
+    writer: mpsc::UnboundedSender<Message>,
+    pending_unary: Arc<Mutex<HashMap<String, UnaryResultTx>>>,
+    pending_streams: Arc<Mutex<HashMap<String, StreamResultTx>>>,
+}
+
+impl WebSocketConnection {
+    async fn connect(url: &str) -> Result<Self, A2AError> {
+        let request = url.into_client_request().map_err(|e| {
+            A2AError::invalid_request(format!("invalid websocket URL '{url}': {e}"))
+        })?;
+        let (ws_stream, _) = connect_async(request)
+            .await
+            .map_err(|e| A2AError::internal(format!("failed to connect websocket: {e}")))?;
+        let (mut ws_writer, mut ws_reader) = ws_stream.split();
+
+        let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<Message>();
+        let pending_unary = Arc::new(Mutex::new(HashMap::new()));
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+
+        tokio::spawn(async move {
+            while let Some(msg) = writer_rx.recv().await {
+                if ws_writer.send(msg).await.is_err() {
+                    break;
+                }
+            }
+            let _ = ws_writer.close().await;
+        });
+
+        let reader_pending_unary = pending_unary.clone();
+        let reader_pending_streams = pending_streams.clone();
+        tokio::spawn(async move {
+            while let Some(next_msg) = ws_reader.next().await {
+                let msg = match next_msg {
+                    Ok(msg) => msg,
+                    Err(error) => {
+                        fail_all_pending(
+                            &reader_pending_unary,
+                            &reader_pending_streams,
+                            A2AError::internal(format!("websocket read error: {error}")),
+                        )
+                        .await;
+                        return;
+                    }
+                };
+
+                match msg {
+                    Message::Text(text) => {
+                        if let Err(error) = route_incoming_frame(
+                            &reader_pending_unary,
+                            &reader_pending_streams,
+                            &text,
+                        )
+                        .await
+                        {
+                            fail_all_pending(&reader_pending_unary, &reader_pending_streams, error)
+                                .await;
+                            return;
+                        }
+                    }
+                    Message::Close(_) => {
+                        fail_all_pending(
+                            &reader_pending_unary,
+                            &reader_pending_streams,
+                            A2AError::unsupported_operation("websocket connection closed"),
+                        )
+                        .await;
+                        return;
+                    }
+                    _ => {}
+                }
+            }
+
+            fail_all_pending(
+                &reader_pending_unary,
+                &reader_pending_streams,
+                A2AError::unsupported_operation("websocket connection closed"),
+            )
+            .await;
+        });
+
+        Ok(Self {
+            writer: writer_tx,
+            pending_unary,
+            pending_streams,
+        })
+    }
+
+    fn send(&self, envelope: &WebSocketRequestEnvelope) -> Result<(), A2AError> {
+        let payload = serde_json::to_string(envelope)
+            .map_err(|e| A2AError::internal(format!("failed to serialize websocket frame: {e}")))?;
+        self.writer
+            .send(Message::Text(payload))
+            .map_err(|_| A2AError::unsupported_operation("websocket connection is not writable"))
+    }
+
+    async fn call_unary_value(
+        &self,
+        method: &str,
+        service_params: &ServiceParams,
+        payload: serde_json::Value,
+    ) -> Result<serde_json::Value, A2AError> {
+        let id = uuid::Uuid::now_v7().to_string();
+        let (tx, rx) = oneshot::channel();
+        self.pending_unary.lock().await.insert(id.clone(), tx);
+
+        let envelope = WebSocketRequestEnvelope::new(
+            JsonRpcId::String(id.clone()),
+            method,
+            Some(payload),
+            (!service_params.is_empty()).then_some(service_params.clone()),
+        );
+        if let Err(error) = self.send(&envelope) {
+            self.pending_unary.lock().await.remove(&id);
+            return Err(error);
+        }
+
+        rx.await
+            .map_err(|_| A2AError::unsupported_operation("websocket response channel closed"))?
+    }
+
+    async fn call_stream(
+        &self,
+        method: &str,
+        service_params: &ServiceParams,
+        payload: serde_json::Value,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        let id = uuid::Uuid::now_v7().to_string();
+        let (stream_tx, stream_rx) = mpsc::unbounded_channel();
+        self.pending_streams
+            .lock()
+            .await
+            .insert(id.clone(), stream_tx);
+
+        let envelope = WebSocketRequestEnvelope::new(
+            JsonRpcId::String(id.clone()),
+            method,
+            Some(payload),
+            (!service_params.is_empty()).then_some(service_params.clone()),
+        );
+        if let Err(error) = self.send(&envelope) {
+            self.pending_streams.lock().await.remove(&id);
+            return Err(error);
+        }
+
+        Ok(Box::pin(UnboundedReceiverStream::new(stream_rx)))
+    }
+}
+
+async fn route_incoming_frame(
+    pending_unary: &Arc<Mutex<HashMap<String, UnaryResultTx>>>,
+    pending_streams: &Arc<Mutex<HashMap<String, StreamResultTx>>>,
+    frame: &str,
+) -> Result<(), A2AError> {
+    let envelope: WebSocketResponseEnvelope = serde_json::from_str(frame)
+        .map_err(|e| A2AError::parse_error(format!("invalid websocket frame: {e}")))?;
+
+    let id = match envelope.id {
+        JsonRpcId::String(id) => id,
+        _ => {
+            return Err(A2AError::invalid_request(
+                "websocket response id must be a string",
+            ));
+        }
+    };
+
+    if let Some(stream_event) = envelope.stream_event {
+        let event = protojson_conv::from_value::<StreamResponse>(stream_event)
+            .map_err(|e| A2AError::internal(format!("failed to parse stream event: {e}")))?;
+        let mut streams = pending_streams.lock().await;
+        if let Some(tx) = streams.get(&id) {
+            if tx.send(Ok(event)).is_err() {
+                streams.remove(&id);
+            }
+        }
+        return Ok(());
+    }
+
+    if let Some(stream_error) = envelope.stream_error {
+        let error = A2AError::new(stream_error.code, stream_error.message);
+        if let Some(tx) = pending_streams.lock().await.get(&id) {
+            let _ = tx.send(Err(error));
+        }
+        pending_streams.lock().await.remove(&id);
+        return Ok(());
+    }
+
+    if envelope.stream_end.unwrap_or(false) {
+        pending_streams.lock().await.remove(&id);
+        return Ok(());
+    }
+
+    let tx = pending_unary.lock().await.remove(&id);
+    if let Some(tx) = tx {
+        if let Some(err) = envelope.error {
+            let _ = tx.send(Err(A2AError::new(err.code, err.message)));
+        } else {
+            let _ = tx.send(Ok(envelope.result.unwrap_or(serde_json::Value::Null)));
+        }
+    }
+
+    Ok(())
+}
+
+async fn fail_all_pending(
+    pending_unary: &Arc<Mutex<HashMap<String, UnaryResultTx>>>,
+    pending_streams: &Arc<Mutex<HashMap<String, StreamResultTx>>>,
+    error: A2AError,
+) {
+    let mut unary = pending_unary.lock().await;
+    for (_, tx) in unary.drain() {
+        let _ = tx.send(Err(error.clone()));
+    }
+    drop(unary);
+
+    let mut streams = pending_streams.lock().await;
+    for (_, tx) in streams.drain() {
+        let _ = tx.send(Err(error.clone()));
+    }
+}
+
+pub struct WebSocketTransport {
+    connection: Arc<WebSocketConnection>,
+}
+
+impl WebSocketTransport {
+    pub async fn connect(url: &str) -> Result<Self, A2AError> {
+        Ok(Self {
+            connection: Arc::new(WebSocketConnection::connect(url).await?),
+        })
+    }
+
+    async fn call<Req, Resp>(
+        &self,
+        params: &ServiceParams,
+        method: &str,
+        request_params: &Req,
+    ) -> Result<Resp, A2AError>
+    where
+        Req: ProtoJsonPayload,
+        Resp: ProtoJsonPayload,
+    {
+        let payload = protojson_conv::to_value(request_params).map_err(|e| {
+            A2AError::internal(format!("failed to serialize request as ProtoJSON: {e}"))
+        })?;
+        let result = self
+            .connection
+            .call_unary_value(method, params, payload)
+            .await?;
+        protojson_conv::from_value(result)
+            .map_err(|e| A2AError::internal(format!("failed to deserialize result: {e}")))
+    }
+
+    async fn call_value<Req>(
+        &self,
+        params: &ServiceParams,
+        method: &str,
+        request_params: &Req,
+    ) -> Result<serde_json::Value, A2AError>
+    where
+        Req: ProtoJsonPayload,
+    {
+        let payload = protojson_conv::to_value(request_params).map_err(|e| {
+            A2AError::internal(format!("failed to serialize request as ProtoJSON: {e}"))
+        })?;
+        self.connection
+            .call_unary_value(method, params, payload)
+            .await
+    }
+
+    async fn call_streaming<Req>(
+        &self,
+        params: &ServiceParams,
+        method: &str,
+        request_params: &Req,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError>
+    where
+        Req: ProtoJsonPayload,
+    {
+        let payload = protojson_conv::to_value(request_params).map_err(|e| {
+            A2AError::internal(format!("failed to serialize request as ProtoJSON: {e}"))
+        })?;
+        self.connection.call_stream(method, params, payload).await
+    }
+}
+
+#[async_trait]
+impl Transport for WebSocketTransport {
+    async fn send_message(
+        &self,
+        params: &ServiceParams,
+        req: &SendMessageRequest,
+    ) -> Result<SendMessageResponse, A2AError> {
+        self.call(params, methods::SEND_MESSAGE, req).await
+    }
+
+    async fn send_streaming_message(
+        &self,
+        params: &ServiceParams,
+        req: &SendMessageRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.call_streaming(params, methods::SEND_STREAMING_MESSAGE, req)
+            .await
+    }
+
+    async fn get_task(
+        &self,
+        params: &ServiceParams,
+        req: &GetTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.call(params, methods::GET_TASK, req).await
+    }
+
+    async fn list_tasks(
+        &self,
+        params: &ServiceParams,
+        req: &ListTasksRequest,
+    ) -> Result<ListTasksResponse, A2AError> {
+        self.call(params, methods::LIST_TASKS, req).await
+    }
+
+    async fn cancel_task(
+        &self,
+        params: &ServiceParams,
+        req: &CancelTaskRequest,
+    ) -> Result<Task, A2AError> {
+        self.call(params, methods::CANCEL_TASK, req).await
+    }
+
+    async fn subscribe_to_task(
+        &self,
+        params: &ServiceParams,
+        req: &SubscribeToTaskRequest,
+    ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+        self.call_streaming(params, methods::SUBSCRIBE_TO_TASK, req)
+            .await
+    }
+
+    async fn create_push_config(
+        &self,
+        params: &ServiceParams,
+        req: &CreateTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        let payload = serialize_create_task_push_notification_config_request(req)?;
+        let value = self
+            .connection
+            .call_unary_value(methods::CREATE_PUSH_CONFIG, params, payload)
+            .await?;
+        deserialize_task_push_notification_config(value)
+    }
+
+    async fn get_push_config(
+        &self,
+        params: &ServiceParams,
+        req: &GetTaskPushNotificationConfigRequest,
+    ) -> Result<TaskPushNotificationConfig, A2AError> {
+        let result = self
+            .call_value(params, methods::GET_PUSH_CONFIG, req)
+            .await?;
+        deserialize_task_push_notification_config(result)
+    }
+
+    async fn list_push_configs(
+        &self,
+        params: &ServiceParams,
+        req: &ListTaskPushNotificationConfigsRequest,
+    ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+        let result = self
+            .call_value(params, methods::LIST_PUSH_CONFIGS, req)
+            .await?;
+        deserialize_list_task_push_notification_configs_response(result)
+    }
+
+    async fn delete_push_config(
+        &self,
+        params: &ServiceParams,
+        req: &DeleteTaskPushNotificationConfigRequest,
+    ) -> Result<(), A2AError> {
+        let _ = self
+            .call_value(params, methods::DELETE_PUSH_CONFIG, req)
+            .await?;
+        Ok(())
+    }
+
+    async fn get_extended_agent_card(
+        &self,
+        params: &ServiceParams,
+        req: &GetExtendedAgentCardRequest,
+    ) -> Result<AgentCard, A2AError> {
+        self.call(params, methods::GET_EXTENDED_AGENT_CARD, req)
+            .await
+    }
+
+    async fn destroy(&self) -> Result<(), A2AError> {
+        let _ = self.connection.writer.send(Message::Close(None));
+        Ok(())
+    }
+}
+
+pub struct WebSocketTransportFactory;
+
+impl WebSocketTransportFactory {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for WebSocketTransportFactory {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl TransportFactory for WebSocketTransportFactory {
+    fn protocol(&self) -> &str {
+        TRANSPORT_PROTOCOL_WEBSOCKET
+    }
+
+    async fn create(
+        &self,
+        _card: &AgentCard,
+        iface: &AgentInterface,
+    ) -> Result<Box<dyn Transport>, A2AError> {
+        if !(iface.url.starts_with("ws://") || iface.url.starts_with("wss://")) {
+            return Err(A2AError::invalid_request(format!(
+                "websocket transport requires ws:// or wss:// URL, got '{}'",
+                iface.url
+            )));
+        }
+        let transport = WebSocketTransport::connect(&iface.url).await?;
+        Ok(Box::new(transport))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a::jsonrpc::JsonRpcId;
+
+    fn test_connection() -> (WebSocketConnection, mpsc::UnboundedReceiver<Message>) {
+        let (writer, rx) = mpsc::unbounded_channel();
+        (
+            WebSocketConnection {
+                writer,
+                pending_unary: Arc::new(Mutex::new(HashMap::new())),
+                pending_streams: Arc::new(Mutex::new(HashMap::new())),
+            },
+            rx,
+        )
+    }
+
+    fn closed_connection() -> WebSocketConnection {
+        let (writer, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        WebSocketConnection {
+            writer,
+            pending_unary: Arc::new(Mutex::new(HashMap::new())),
+            pending_streams: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[test]
+    fn test_factory_protocol() {
+        let factory = WebSocketTransportFactory::new();
+        assert_eq!(factory.protocol(), TRANSPORT_PROTOCOL_WEBSOCKET);
+    }
+
+    #[test]
+    fn test_factory_default() {
+        let factory = WebSocketTransportFactory::default();
+        assert_eq!(factory.protocol(), TRANSPORT_PROTOCOL_WEBSOCKET);
+    }
+
+    #[test]
+    fn test_connection_send_writes_text_frame() {
+        let (connection, mut rx) = test_connection();
+        let envelope = WebSocketRequestEnvelope::new(
+            JsonRpcId::String("id".into()),
+            methods::GET_TASK,
+            Some(serde_json::json!({"id": "task-1"})),
+            None,
+        );
+
+        connection.send(&envelope).unwrap();
+
+        let sent = rx.try_recv().unwrap();
+        let text = sent.into_text().unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], "id");
+        assert_eq!(value["method"], methods::GET_TASK);
+    }
+
+    #[test]
+    fn test_connection_send_closed_writer() {
+        let connection = closed_connection();
+        let envelope = WebSocketRequestEnvelope::new(
+            JsonRpcId::String("id".into()),
+            methods::GET_TASK,
+            None,
+            None,
+        );
+
+        let err = connection.send(&envelope).unwrap_err();
+        assert_eq!(err.code, error_code::UNSUPPORTED_OPERATION);
+    }
+
+    #[tokio::test]
+    async fn test_call_unary_value_sends_service_params_and_receives_result() {
+        let (connection, mut rx) = test_connection();
+        let mut params = ServiceParams::new();
+        params.insert("x-test".to_string(), vec!["value".to_string()]);
+        let pending = connection.pending_unary.clone();
+
+        let call = tokio::spawn(async move {
+            connection
+                .call_unary_value(
+                    methods::GET_TASK,
+                    &params,
+                    serde_json::json!({"id": "task-1"}),
+                )
+                .await
+        });
+
+        let sent = rx.recv().await.unwrap();
+        let text = sent.into_text().unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let id = value["id"].as_str().unwrap().to_string();
+        assert_eq!(value["serviceParams"]["x-test"][0], "value");
+
+        let response = WebSocketResponseEnvelope::success(
+            JsonRpcId::String(id),
+            serde_json::json!({"id": "task-1"}),
+        );
+        let frame = serde_json::to_string(&response).unwrap();
+        route_incoming_frame(&pending, &Arc::new(Mutex::new(HashMap::new())), &frame)
+            .await
+            .unwrap();
+
+        let result = call.await.unwrap().unwrap();
+        assert_eq!(result["id"], "task-1");
+    }
+
+    #[tokio::test]
+    async fn test_call_unary_value_removes_pending_on_send_error() {
+        let connection = closed_connection();
+        let err = connection
+            .call_unary_value(
+                methods::GET_TASK,
+                &ServiceParams::new(),
+                serde_json::json!({}),
+            )
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code, error_code::UNSUPPORTED_OPERATION);
+        assert!(connection.pending_unary.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_call_stream_sends_frame_and_stream_end_removes_pending() {
+        let (connection, mut rx) = test_connection();
+        let pending_streams = connection.pending_streams.clone();
+        let stream = connection
+            .call_stream(
+                methods::SUBSCRIBE_TO_TASK,
+                &ServiceParams::new(),
+                serde_json::json!({"id": "task-1"}),
+            )
+            .await
+            .unwrap();
+
+        let sent = rx.recv().await.unwrap();
+        let text = sent.into_text().unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let id = value["id"].as_str().unwrap().to_string();
+        assert_eq!(value["method"], methods::SUBSCRIBE_TO_TASK);
+        assert!(pending_streams.lock().await.contains_key(&id));
+
+        let response = WebSocketResponseEnvelope::stream_end(JsonRpcId::String(id.clone()));
+        let frame = serde_json::to_string(&response).unwrap();
+        route_incoming_frame(
+            &Arc::new(Mutex::new(HashMap::new())),
+            &pending_streams,
+            &frame,
+        )
+        .await
+        .unwrap();
+
+        assert!(!pending_streams.lock().await.contains_key(&id));
+        drop(stream);
+    }
+
+    #[tokio::test]
+    async fn test_call_stream_removes_pending_on_send_error() {
+        let connection = closed_connection();
+        let result = connection
+            .call_stream(
+                methods::SUBSCRIBE_TO_TASK,
+                &ServiceParams::new(),
+                serde_json::json!({}),
+            )
+            .await;
+        let err = match result {
+            Ok(_) => panic!("expected call_stream to fail"),
+            Err(err) => err,
+        };
+
+        assert_eq!(err.code, error_code::UNSUPPORTED_OPERATION);
+        assert!(connection.pending_streams.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_frame_success() {
+        let pending_unary = Arc::new(Mutex::new(HashMap::new()));
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, rx) = oneshot::channel();
+        pending_unary.lock().await.insert("test-id".to_string(), tx);
+
+        let response = WebSocketResponseEnvelope::success(
+            JsonRpcId::String("test-id".into()),
+            serde_json::json!({"result": "ok"}),
+        );
+        let frame = serde_json::to_string(&response).unwrap();
+        route_incoming_frame(&pending_unary, &pending_streams, &frame)
+            .await
+            .unwrap();
+
+        let result = rx.await.unwrap().unwrap();
+        assert_eq!(result, serde_json::json!({"result": "ok"}));
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_frame_error() {
+        let pending_unary = Arc::new(Mutex::new(HashMap::new()));
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, rx) = oneshot::channel();
+        pending_unary.lock().await.insert("test-id".to_string(), tx);
+
+        let error = JsonRpcError {
+            code: -32600,
+            message: "Invalid request".to_string(),
+            data: None,
+        };
+        let response = WebSocketResponseEnvelope::error(JsonRpcId::String("test-id".into()), error);
+        let frame = serde_json::to_string(&response).unwrap();
+        route_incoming_frame(&pending_unary, &pending_streams, &frame)
+            .await
+            .unwrap();
+
+        let result = rx.await.unwrap().unwrap_err();
+        assert_eq!(result.code, -32600);
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_frame_invalid_json() {
+        let pending_unary = Arc::new(Mutex::new(HashMap::new()));
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+
+        let result = route_incoming_frame(&pending_unary, &pending_streams, "invalid json").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::PARSE_ERROR);
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_frame_non_string_id() {
+        let pending_unary = Arc::new(Mutex::new(HashMap::new()));
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+
+        let response =
+            WebSocketResponseEnvelope::success(JsonRpcId::Number(123), serde_json::json!({}));
+        let frame = serde_json::to_string(&response).unwrap();
+        let result = route_incoming_frame(&pending_unary, &pending_streams, &frame).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_fail_all_pending() {
+        let pending_unary = Arc::new(Mutex::new(HashMap::new()));
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+        let (tx1, rx1) = oneshot::channel();
+        let (tx2, rx2) = oneshot::channel();
+        let (stream_tx, mut stream_rx) = mpsc::unbounded_channel();
+
+        pending_unary.lock().await.insert("id1".to_string(), tx1);
+        pending_unary.lock().await.insert("id2".to_string(), tx2);
+        pending_streams
+            .lock()
+            .await
+            .insert("stream-id".to_string(), stream_tx);
+
+        let error = A2AError::internal("test error");
+        fail_all_pending(&pending_unary, &pending_streams, error.clone()).await;
+
+        assert!(rx1.await.unwrap().unwrap_err().code == error.code);
+        assert!(rx2.await.unwrap().unwrap_err().code == error.code);
+        assert!(stream_rx.recv().await.unwrap().unwrap_err().code == error.code);
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_frame_stream_end() {
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, _rx) = mpsc::unbounded_channel();
+        pending_streams
+            .lock()
+            .await
+            .insert("test-id".to_string(), tx);
+
+        let response = WebSocketResponseEnvelope::stream_end(JsonRpcId::String("test-id".into()));
+        let frame = serde_json::to_string(&response).unwrap();
+        route_incoming_frame(
+            &Arc::new(Mutex::new(HashMap::new())),
+            &pending_streams,
+            &frame,
+        )
+        .await
+        .unwrap();
+
+        assert!(pending_streams.lock().await.get("test-id").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_frame_stream_error() {
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        pending_streams
+            .lock()
+            .await
+            .insert("test-id".to_string(), tx);
+        let error = JsonRpcError {
+            code: error_code::INTERNAL_ERROR,
+            message: "stream failed".to_string(),
+            data: None,
+        };
+        let response =
+            WebSocketResponseEnvelope::stream_error(JsonRpcId::String("test-id".into()), error);
+        let frame = serde_json::to_string(&response).unwrap();
+
+        route_incoming_frame(
+            &Arc::new(Mutex::new(HashMap::new())),
+            &pending_streams,
+            &frame,
+        )
+        .await
+        .unwrap();
+
+        let err = rx.recv().await.unwrap().unwrap_err();
+        assert_eq!(err.code, error_code::INTERNAL_ERROR);
+        assert!(pending_streams.lock().await.get("test-id").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_route_incoming_frame_stream_event_drops_closed_sender() {
+        let pending_streams = Arc::new(Mutex::new(HashMap::new()));
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        pending_streams
+            .lock()
+            .await
+            .insert("test-id".to_string(), tx);
+        let event = StreamResponse::Task(Task {
+            id: "task-1".to_string(),
+            context_id: "ctx".to_string(),
+            status: TaskStatus {
+                state: TaskState::Completed,
+                message: None,
+                timestamp: None,
+            },
+            artifacts: None,
+            history: None,
+            metadata: None,
+        });
+        let response = WebSocketResponseEnvelope::stream_event(
+            JsonRpcId::String("test-id".into()),
+            protojson_conv::to_value(&event).unwrap(),
+        );
+        let frame = serde_json::to_string(&response).unwrap();
+
+        route_incoming_frame(
+            &Arc::new(Mutex::new(HashMap::new())),
+            &pending_streams,
+            &frame,
+        )
+        .await
+        .unwrap();
+
+        assert!(pending_streams.lock().await.get("test-id").is_none());
+    }
+}

--- a/a2a-server/src/lib.rs
+++ b/a2a-server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod sse;
 pub mod task_store;
 #[cfg(feature = "rustls")]
 pub mod tls;
+pub mod websocket;
 
 pub use agent_card::{AgentCardProducer, StaticAgentCard, WELL_KNOWN_AGENT_CARD_PATH};
 pub use executor::{AgentExecutor, ExecutorContext};

--- a/a2a-server/src/websocket.rs
+++ b/a2a-server/src/websocket.rs
@@ -1,0 +1,934 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use std::sync::Arc;
+
+use a2a::websocket::{WebSocketRequestEnvelope, WebSocketResponseEnvelope};
+use a2a::*;
+use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use futures::{SinkExt, StreamExt, stream::BoxStream};
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::handler::RequestHandler;
+use crate::middleware::ServiceParams;
+use crate::push_config_compat::json_value as compat_json_value;
+
+/// Shared state for the WebSocket handler.
+pub struct WebSocketState<H: RequestHandler> {
+    pub handler: Arc<H>,
+}
+
+impl<H: RequestHandler> Clone for WebSocketState<H> {
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+/// Create an axum router for the WebSocket protocol binding.
+pub fn websocket_router<H: RequestHandler>(handler: Arc<H>) -> axum::Router {
+    let state = WebSocketState { handler };
+    axum::Router::new()
+        .route("/", axum::routing::get(handle_websocket::<H>))
+        .with_state(state)
+}
+
+async fn handle_websocket<H: RequestHandler>(
+    State(state): State<WebSocketState<H>>,
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+) -> impl IntoResponse {
+    let connection_params = service_params_from_headers(&headers);
+    ws.on_upgrade(move |socket| serve_socket(socket, state, connection_params))
+}
+
+async fn serve_socket<H: RequestHandler>(
+    socket: WebSocket,
+    state: WebSocketState<H>,
+    connection_params: ServiceParams,
+) {
+    let (mut sender, mut receiver) = socket.split();
+    let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<Message>();
+
+    let writer = tokio::spawn(async move {
+        while let Some(message) = outgoing_rx.recv().await {
+            if sender.send(message).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    while let Some(next) = receiver.next().await {
+        let message = match next {
+            Ok(msg) => msg,
+            Err(_) => break,
+        };
+
+        match message {
+            Message::Text(frame) => {
+                handle_text_frame(
+                    frame.as_str(),
+                    &state,
+                    &connection_params,
+                    outgoing_tx.clone(),
+                )
+                .await;
+            }
+            Message::Binary(_) => {
+                let _ = outgoing_tx.send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                    code: axum::extract::ws::close_code::UNSUPPORTED,
+                    reason: "binary websocket frames are not supported".into(),
+                })));
+                break;
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+    }
+
+    drop(outgoing_tx);
+    let _ = writer.await;
+}
+
+async fn handle_text_frame<H: RequestHandler>(
+    frame: &str,
+    state: &WebSocketState<H>,
+    connection_params: &ServiceParams,
+    outgoing_tx: mpsc::UnboundedSender<Message>,
+) {
+    let request: WebSocketRequestEnvelope = match serde_json::from_str(frame) {
+        Ok(request) => request,
+        Err(error) => {
+            let _ = send_response(
+                &outgoing_tx,
+                WebSocketResponseEnvelope::error(
+                    JsonRpcId::Null,
+                    parse_error(format!("invalid websocket frame: {error}")).to_jsonrpc_error(),
+                ),
+            );
+            return;
+        }
+    };
+
+    if request.jsonrpc != "2.0" {
+        let _ = send_response(
+            &outgoing_tx,
+            WebSocketResponseEnvelope::error(
+                request.id,
+                A2AError::invalid_request("invalid jsonrpc version").to_jsonrpc_error(),
+            ),
+        );
+        return;
+    }
+
+    let mut params = connection_params.clone();
+    if let Some(message_params) = request.service_params.as_ref() {
+        for (key, values) in message_params {
+            params.insert(key.clone(), values.clone());
+        }
+    }
+
+    if methods::is_streaming(&request.method) {
+        spawn_streaming_call(state, params, request, outgoing_tx);
+        return;
+    }
+
+    let id = request.id.clone();
+    let result = handle_unary_request(state, &params, &request).await;
+    let response = match result {
+        Ok(value) => WebSocketResponseEnvelope::success(id, value),
+        Err(error) => WebSocketResponseEnvelope::error(id, error.to_jsonrpc_error()),
+    };
+    let _ = send_response(&outgoing_tx, response);
+}
+
+fn spawn_streaming_call<H: RequestHandler>(
+    state: &WebSocketState<H>,
+    params: ServiceParams,
+    request: WebSocketRequestEnvelope,
+    outgoing_tx: mpsc::UnboundedSender<Message>,
+) {
+    let handler = state.handler.clone();
+    tokio::spawn(async move {
+        let id = request.id.clone();
+        let raw_params = request.params.unwrap_or(Value::Null);
+
+        let stream_result: Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> =
+            match request.method.as_str() {
+                methods::SEND_STREAMING_MESSAGE => {
+                    match protojson_conv::from_value::<SendMessageRequest>(raw_params) {
+                        Ok(req) => handler.send_streaming_message(&params, req).await,
+                        Err(error) => Err(invalid_params_error(error)),
+                    }
+                }
+                methods::SUBSCRIBE_TO_TASK => {
+                    match protojson_conv::from_value::<SubscribeToTaskRequest>(raw_params) {
+                        Ok(req) => handler.subscribe_to_task(&params, req).await,
+                        Err(error) => Err(invalid_params_error(error)),
+                    }
+                }
+                _ => Err(A2AError::method_not_found(&request.method)),
+            };
+
+        let mut stream = match stream_result {
+            Ok(stream) => stream,
+            Err(error) => {
+                let _ = send_response(
+                    &outgoing_tx,
+                    WebSocketResponseEnvelope::error(id, error.to_jsonrpc_error()),
+                );
+                return;
+            }
+        };
+
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(event) => match protojson_conv::to_value(&event) {
+                    Ok(value) => {
+                        let _ = send_response(
+                            &outgoing_tx,
+                            WebSocketResponseEnvelope::stream_event(id.clone(), value),
+                        );
+                    }
+                    Err(error) => {
+                        let _ = send_response(
+                            &outgoing_tx,
+                            WebSocketResponseEnvelope::stream_error(
+                                id.clone(),
+                                A2AError::internal(format!(
+                                    "failed to serialize ProtoJSON stream payload: {error}"
+                                ))
+                                .to_jsonrpc_error(),
+                            ),
+                        );
+                        return;
+                    }
+                },
+                Err(error) => {
+                    let _ = send_response(
+                        &outgoing_tx,
+                        WebSocketResponseEnvelope::stream_error(
+                            id.clone(),
+                            error.to_jsonrpc_error(),
+                        ),
+                    );
+                    return;
+                }
+            }
+        }
+
+        let _ = send_response(&outgoing_tx, WebSocketResponseEnvelope::stream_end(id));
+    });
+}
+
+async fn handle_unary_request<H: RequestHandler>(
+    state: &WebSocketState<H>,
+    params: &ServiceParams,
+    request: &WebSocketRequestEnvelope,
+) -> Result<Value, A2AError> {
+    let raw_params = request.params.clone().unwrap_or(Value::Null);
+
+    match request.method.as_str() {
+        methods::SEND_MESSAGE => match protojson_conv::from_value::<SendMessageRequest>(raw_params)
+        {
+            Ok(req) => state
+                .handler
+                .send_message(params, req)
+                .await
+                .and_then(|r| protojson_value(&r)),
+            Err(e) => Err(invalid_params_error(e)),
+        },
+        methods::GET_TASK => match protojson_conv::from_value::<GetTaskRequest>(raw_params) {
+            Ok(req) => state
+                .handler
+                .get_task(params, req)
+                .await
+                .and_then(|r| protojson_value(&r)),
+            Err(e) => Err(invalid_params_error(e)),
+        },
+        methods::LIST_TASKS => match protojson_conv::from_value::<ListTasksRequest>(raw_params) {
+            Ok(req) => state
+                .handler
+                .list_tasks(params, req)
+                .await
+                .and_then(|r| protojson_value(&r)),
+            Err(e) => Err(invalid_params_error(e)),
+        },
+        methods::CANCEL_TASK => match protojson_conv::from_value::<CancelTaskRequest>(raw_params) {
+            Ok(req) => state
+                .handler
+                .cancel_task(params, req)
+                .await
+                .and_then(|r| protojson_value(&r)),
+            Err(e) => Err(invalid_params_error(e)),
+        },
+        methods::CREATE_PUSH_CONFIG => match parse_create_push_config_request(raw_params) {
+            Ok(req) => state
+                .handler
+                .create_push_config(params, req)
+                .await
+                .and_then(|r| compat_json_value(&r)),
+            Err(e) => Err(invalid_params_error(e)),
+        },
+        methods::GET_PUSH_CONFIG => {
+            match protojson_conv::from_value::<GetTaskPushNotificationConfigRequest>(raw_params) {
+                Ok(req) => state
+                    .handler
+                    .get_push_config(params, req)
+                    .await
+                    .and_then(|r| compat_json_value(&r)),
+                Err(e) => Err(invalid_params_error(e)),
+            }
+        }
+        methods::LIST_PUSH_CONFIGS => {
+            match protojson_conv::from_value::<ListTaskPushNotificationConfigsRequest>(raw_params) {
+                Ok(req) => state
+                    .handler
+                    .list_push_configs(params, req)
+                    .await
+                    .and_then(|r| compat_json_value(&r)),
+                Err(e) => Err(invalid_params_error(e)),
+            }
+        }
+        methods::DELETE_PUSH_CONFIG => {
+            match protojson_conv::from_value::<DeleteTaskPushNotificationConfigRequest>(raw_params)
+            {
+                Ok(req) => state
+                    .handler
+                    .delete_push_config(params, req)
+                    .await
+                    .map(|_| Value::Null),
+                Err(e) => Err(invalid_params_error(e)),
+            }
+        }
+        methods::GET_EXTENDED_AGENT_CARD => {
+            match protojson_conv::from_value::<GetExtendedAgentCardRequest>(raw_params) {
+                Ok(req) => state
+                    .handler
+                    .get_extended_agent_card(params, req)
+                    .await
+                    .and_then(|r| protojson_value(&r)),
+                Err(e) => Err(invalid_params_error(e)),
+            }
+        }
+        "" => Err(A2AError::invalid_request("method is required")),
+        _ => Err(A2AError::method_not_found(&request.method)),
+    }
+}
+
+fn send_response(
+    outgoing_tx: &mpsc::UnboundedSender<Message>,
+    response: WebSocketResponseEnvelope,
+) -> Result<(), A2AError> {
+    let payload = serde_json::to_string(&response)
+        .map_err(|e| A2AError::internal(format!("failed to serialize websocket frame: {e}")))?;
+    outgoing_tx
+        .send(Message::Text(payload.into()))
+        .map_err(|_| A2AError::unsupported_operation("websocket output channel is closed"))
+}
+
+fn service_params_from_headers(headers: &HeaderMap) -> ServiceParams {
+    let mut params = ServiceParams::new();
+    for (name, value) in headers {
+        if let Ok(text) = value.to_str() {
+            params
+                .entry(name.as_str().to_string())
+                .or_default()
+                .push(text.to_string());
+        }
+    }
+    params
+}
+
+fn protojson_value<T: ProtoJsonPayload>(value: &T) -> Result<Value, A2AError> {
+    protojson_conv::to_value(value)
+        .map_err(|e| A2AError::internal(format!("failed to serialize ProtoJSON payload: {e}")))
+}
+
+fn parse_create_push_config_request(
+    raw_params: Value,
+) -> Result<CreateTaskPushNotificationConfigRequest, String> {
+    match protojson_conv::from_value::<CreateTaskPushNotificationConfigRequest>(raw_params.clone())
+    {
+        Ok(req) => Ok(req),
+        Err(protojson_error) => serde_json::from_value::<CreateTaskPushNotificationConfigRequest>(
+            raw_params,
+        )
+        .map_err(|serde_error| {
+            format!("{protojson_error}; nested request parse failed: {serde_error}")
+        }),
+    }
+}
+
+fn parse_error(e: impl std::fmt::Display) -> A2AError {
+    A2AError::parse_error(&e.to_string())
+}
+
+fn invalid_params_error(e: impl std::fmt::Display) -> A2AError {
+    A2AError::invalid_params(e.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a::jsonrpc::JsonRpcId;
+    use a2a::websocket::WebSocketRequestEnvelope;
+    use async_trait::async_trait;
+    use axum::http::header::HeaderValue;
+    use futures::stream;
+
+    struct MockHandler {
+        fail: bool,
+    }
+
+    impl MockHandler {
+        fn ok() -> Arc<Self> {
+            Arc::new(Self { fail: false })
+        }
+        fn failing() -> Arc<Self> {
+            Arc::new(Self { fail: true })
+        }
+    }
+
+    #[async_trait]
+    impl RequestHandler for MockHandler {
+        async fn send_message(
+            &self,
+            _: &ServiceParams,
+            _: SendMessageRequest,
+        ) -> Result<SendMessageResponse, A2AError> {
+            if self.fail {
+                return Err(A2AError::internal("fail"));
+            }
+            Ok(SendMessageResponse::Task(Task {
+                id: "t1".to_string(),
+                context_id: "ctx".to_string(),
+                status: TaskStatus {
+                    state: TaskState::Submitted,
+                    message: None,
+                    timestamp: None,
+                },
+                history: None,
+                artifacts: None,
+                metadata: None,
+            }))
+        }
+        async fn send_streaming_message(
+            &self,
+            _: &ServiceParams,
+            _: SendMessageRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            if self.fail {
+                return Err(A2AError::internal("stream-fail"));
+            }
+            Ok(Box::pin(stream::iter(vec![Ok(StreamResponse::Task(
+                Task {
+                    id: "t1".to_string(),
+                    context_id: "ctx".to_string(),
+                    status: TaskStatus {
+                        state: TaskState::Completed,
+                        message: None,
+                        timestamp: None,
+                    },
+                    history: None,
+                    artifacts: None,
+                    metadata: None,
+                },
+            ))])))
+        }
+        async fn get_task(&self, _: &ServiceParams, req: GetTaskRequest) -> Result<Task, A2AError> {
+            if req.id == "missing" {
+                return Err(A2AError::task_not_found(&req.id));
+            }
+            Ok(Task {
+                id: req.id,
+                context_id: "ctx".to_string(),
+                status: TaskStatus {
+                    state: TaskState::Completed,
+                    message: None,
+                    timestamp: None,
+                },
+                history: None,
+                artifacts: None,
+                metadata: None,
+            })
+        }
+        async fn list_tasks(
+            &self,
+            _: &ServiceParams,
+            _: ListTasksRequest,
+        ) -> Result<ListTasksResponse, A2AError> {
+            Ok(ListTasksResponse {
+                tasks: vec![],
+                next_page_token: "".into(),
+                page_size: 0,
+                total_size: 0,
+            })
+        }
+        async fn cancel_task(
+            &self,
+            _: &ServiceParams,
+            req: CancelTaskRequest,
+        ) -> Result<Task, A2AError> {
+            Ok(Task {
+                id: req.id,
+                context_id: "ctx".to_string(),
+                status: TaskStatus {
+                    state: TaskState::Canceled,
+                    message: None,
+                    timestamp: None,
+                },
+                history: None,
+                artifacts: None,
+                metadata: None,
+            })
+        }
+        async fn subscribe_to_task(
+            &self,
+            _: &ServiceParams,
+            _: SubscribeToTaskRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            Ok(Box::pin(stream::empty()))
+        }
+        async fn create_push_config(
+            &self,
+            _: &ServiceParams,
+            req: CreateTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            Ok(TaskPushNotificationConfig {
+                task_id: req.task_id,
+                config: req.config,
+                tenant: req.tenant,
+            })
+        }
+        async fn get_push_config(
+            &self,
+            _: &ServiceParams,
+            req: GetTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            Ok(TaskPushNotificationConfig {
+                task_id: req.task_id,
+                config: PushNotificationConfig {
+                    url: "http://cb".into(),
+                    id: None,
+                    token: None,
+                    authentication: None,
+                },
+                tenant: req.tenant,
+            })
+        }
+        async fn list_push_configs(
+            &self,
+            _: &ServiceParams,
+            req: ListTaskPushNotificationConfigsRequest,
+        ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+            Ok(ListTaskPushNotificationConfigsResponse {
+                configs: vec![TaskPushNotificationConfig {
+                    task_id: req.task_id,
+                    config: PushNotificationConfig {
+                        url: "http://cb".into(),
+                        id: None,
+                        token: None,
+                        authentication: None,
+                    },
+                    tenant: req.tenant,
+                }],
+                next_page_token: None,
+            })
+        }
+        async fn delete_push_config(
+            &self,
+            _: &ServiceParams,
+            _: DeleteTaskPushNotificationConfigRequest,
+        ) -> Result<(), A2AError> {
+            Ok(())
+        }
+        async fn get_extended_agent_card(
+            &self,
+            _: &ServiceParams,
+            _: GetExtendedAgentCardRequest,
+        ) -> Result<AgentCard, A2AError> {
+            Ok(AgentCard {
+                name: "test".into(),
+                description: "".into(),
+                version: "1".into(),
+                capabilities: AgentCapabilities::default(),
+                supported_interfaces: vec![],
+                default_input_modes: vec![],
+                default_output_modes: vec![],
+                skills: vec![],
+                provider: None,
+                documentation_url: None,
+                icon_url: None,
+                security_schemes: None,
+                security_requirements: None,
+                signatures: None,
+            })
+        }
+    }
+
+    fn make_state(
+        handler: Arc<MockHandler>,
+    ) -> (
+        WebSocketState<MockHandler>,
+        mpsc::UnboundedSender<Message>,
+        mpsc::UnboundedReceiver<Message>,
+    ) {
+        let state = WebSocketState { handler };
+        let (tx, rx) = mpsc::unbounded_channel();
+        (state, tx, rx)
+    }
+
+    fn unary_request(method: &str, params: serde_json::Value) -> WebSocketRequestEnvelope {
+        WebSocketRequestEnvelope::new(
+            JsonRpcId::String("req-1".into()),
+            method,
+            Some(params),
+            None,
+        )
+    }
+
+    fn typed_params<T: ProtoJsonPayload>(value: &T) -> serde_json::Value {
+        protojson_conv::to_value(value).unwrap()
+    }
+
+    fn message_request() -> SendMessageRequest {
+        SendMessageRequest {
+            message: a2a::Message {
+                message_id: "m1".to_string(),
+                context_id: None,
+                task_id: None,
+                role: Role::User,
+                parts: vec![Part::text("hello")],
+                metadata: None,
+                extensions: None,
+                reference_task_ids: None,
+            },
+            configuration: None,
+            metadata: None,
+            tenant: None,
+        }
+    }
+
+    fn push_config() -> PushNotificationConfig {
+        PushNotificationConfig {
+            url: "http://cb".to_string(),
+            id: Some("cfg-1".to_string()),
+            token: None,
+            authentication: None,
+        }
+    }
+
+    async fn recv_response(rx: &mut mpsc::UnboundedReceiver<Message>) -> serde_json::Value {
+        let msg = rx.recv().await.unwrap();
+        let text = match msg {
+            Message::Text(t) => t.to_string(),
+            _ => panic!("expected text frame"),
+        };
+        serde_json::from_str(&text).unwrap()
+    }
+
+    #[test]
+    fn test_send_response_ok() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let resp = WebSocketResponseEnvelope::success(
+            JsonRpcId::String("id".into()),
+            serde_json::json!({}),
+        );
+        assert!(send_response(&tx, resp).is_ok());
+    }
+
+    #[test]
+    fn test_send_response_closed_channel() {
+        let (tx, rx) = mpsc::unbounded_channel::<Message>();
+        drop(rx);
+        let resp = WebSocketResponseEnvelope::success(
+            JsonRpcId::String("id".into()),
+            serde_json::json!({}),
+        );
+        assert!(send_response(&tx, resp).is_err());
+    }
+
+    #[test]
+    fn test_service_params_from_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-custom", "value1".parse().unwrap());
+        headers.insert("x-multi", "value2".parse().unwrap());
+        headers.append("x-multi", "value3".parse().unwrap());
+        let params = service_params_from_headers(&headers);
+        assert_eq!(params.get("x-custom"), Some(&vec!["value1".to_string()]));
+        assert_eq!(
+            params.get("x-multi"),
+            Some(&vec!["value2".to_string(), "value3".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_service_params_from_headers_empty() {
+        assert!(service_params_from_headers(&HeaderMap::new()).is_empty());
+    }
+
+    #[test]
+    fn test_service_params_from_headers_invalid_utf8() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-valid", "value".parse().unwrap());
+        headers.insert("x-invalid", HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap());
+        let params = service_params_from_headers(&headers);
+        assert_eq!(params.get("x-valid"), Some(&vec!["value".to_string()]));
+        assert!(params.get("x-invalid").is_none());
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let e = parse_error("bad input");
+        assert_eq!(e.code, error_code::PARSE_ERROR);
+        assert!(e.message.contains("bad input"));
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_get_task_ok() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let params = typed_params(&GetTaskRequest {
+            id: "task-1".to_string(),
+            history_length: None,
+            tenant: None,
+        });
+        let req = unary_request(methods::GET_TASK, params);
+        let result = handle_unary_request(&state, &ServiceParams::new(), &req).await;
+        assert!(result.is_ok());
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_get_task_not_found() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let params = typed_params(&GetTaskRequest {
+            id: "missing".to_string(),
+            history_length: None,
+            tenant: None,
+        });
+        let req = unary_request(methods::GET_TASK, params);
+        let result = handle_unary_request(&state, &ServiceParams::new(), &req).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().code, error_code::TASK_NOT_FOUND);
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_list_tasks() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let params = typed_params(&ListTasksRequest {
+            context_id: None,
+            status: None,
+            page_size: None,
+            page_token: None,
+            history_length: None,
+            status_timestamp_after: None,
+            include_artifacts: None,
+            tenant: None,
+        });
+        let req = unary_request(methods::LIST_TASKS, params);
+        assert!(
+            handle_unary_request(&state, &ServiceParams::new(), &req)
+                .await
+                .is_ok()
+        );
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_cancel_task() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let params = typed_params(&CancelTaskRequest {
+            id: "task-1".to_string(),
+            metadata: None,
+            tenant: None,
+        });
+        let req = unary_request(methods::CANCEL_TASK, params);
+        assert!(
+            handle_unary_request(&state, &ServiceParams::new(), &req)
+                .await
+                .is_ok()
+        );
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_send_message() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let req = unary_request(methods::SEND_MESSAGE, typed_params(&message_request()));
+        assert!(
+            handle_unary_request(&state, &ServiceParams::new(), &req)
+                .await
+                .is_ok()
+        );
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_send_message_fail() {
+        let (state, tx, rx) = make_state(MockHandler::failing());
+        let req = unary_request(methods::SEND_MESSAGE, typed_params(&message_request()));
+        assert!(
+            handle_unary_request(&state, &ServiceParams::new(), &req)
+                .await
+                .is_err()
+        );
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_unknown_method() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let req = unary_request("tasks/unknown", serde_json::json!({}));
+        let result = handle_unary_request(&state, &ServiceParams::new(), &req).await;
+        assert_eq!(result.unwrap_err().code, error_code::METHOD_NOT_FOUND);
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_get_extended_agent_card() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let params = typed_params(&GetExtendedAgentCardRequest { tenant: None });
+        let req = unary_request(methods::GET_EXTENDED_AGENT_CARD, params);
+        assert!(
+            handle_unary_request(&state, &ServiceParams::new(), &req)
+                .await
+                .is_ok()
+        );
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_unary_push_config_crud() {
+        let (state, tx, rx) = make_state(MockHandler::ok());
+        let create_req = unary_request(
+            methods::CREATE_PUSH_CONFIG,
+            typed_params(&CreateTaskPushNotificationConfigRequest {
+                task_id: "t1".to_string(),
+                config: push_config(),
+                tenant: None,
+            }),
+        );
+        let get_req = unary_request(
+            methods::GET_PUSH_CONFIG,
+            typed_params(&GetTaskPushNotificationConfigRequest {
+                task_id: "t1".to_string(),
+                id: "cfg-1".to_string(),
+                tenant: None,
+            }),
+        );
+        let list_req = unary_request(
+            methods::LIST_PUSH_CONFIGS,
+            typed_params(&ListTaskPushNotificationConfigsRequest {
+                task_id: "t1".to_string(),
+                page_size: None,
+                page_token: None,
+                tenant: None,
+            }),
+        );
+        let del_req = unary_request(
+            methods::DELETE_PUSH_CONFIG,
+            typed_params(&DeleteTaskPushNotificationConfigRequest {
+                task_id: "t1".to_string(),
+                id: "cfg-1".to_string(),
+                tenant: None,
+            }),
+        );
+        let p = ServiceParams::new();
+        assert!(handle_unary_request(&state, &p, &create_req).await.is_ok());
+        assert!(handle_unary_request(&state, &p, &get_req).await.is_ok());
+        assert!(handle_unary_request(&state, &p, &list_req).await.is_ok());
+        assert!(handle_unary_request(&state, &p, &del_req).await.is_ok());
+        drop(tx);
+        drop(rx);
+    }
+
+    #[tokio::test]
+    async fn test_handle_text_frame_invalid_version_sends_error() {
+        let (state, tx, mut rx) = make_state(MockHandler::ok());
+        let frame = r#"{"jsonrpc":"1.0","id":"x","method":"GetTask","params":{"id":"t1"}}"#;
+        handle_text_frame(frame, &state, &ServiceParams::new(), tx).await;
+        let val = recv_response(&mut rx).await;
+        assert_eq!(val["error"]["code"], error_code::INVALID_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_handle_text_frame_parse_error() {
+        let (state, tx, mut rx) = make_state(MockHandler::ok());
+        handle_text_frame("not-json", &state, &ServiceParams::new(), tx).await;
+        let val = recv_response(&mut rx).await;
+        assert_eq!(val["error"]["code"], error_code::PARSE_ERROR);
+    }
+
+    #[tokio::test]
+    async fn test_handle_text_frame_unary_ok() {
+        let (state, tx, mut rx) = make_state(MockHandler::ok());
+        let frame = r#"{"jsonrpc":"2.0","id":"x","method":"GetTask","params":{"id":"t1"}}"#;
+        handle_text_frame(frame, &state, &ServiceParams::new(), tx).await;
+        let val = recv_response(&mut rx).await;
+        assert!(val["result"].is_object());
+    }
+
+    #[tokio::test]
+    async fn test_handle_text_frame_unary_error() {
+        let (state, tx, mut rx) = make_state(MockHandler::ok());
+        let frame = r#"{"jsonrpc":"2.0","id":"x","method":"GetTask","params":{"id":"missing"}}"#;
+        handle_text_frame(frame, &state, &ServiceParams::new(), tx).await;
+        let val = recv_response(&mut rx).await;
+        assert_eq!(val["error"]["code"], error_code::TASK_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_spawn_streaming_call_ok() {
+        let (state, tx, mut rx) = make_state(MockHandler::ok());
+        let req = WebSocketRequestEnvelope::new(
+            JsonRpcId::String("s1".into()),
+            methods::SEND_STREAMING_MESSAGE,
+            Some(typed_params(&message_request())),
+            None,
+        );
+        spawn_streaming_call(&state, ServiceParams::new(), req, tx);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        let first = recv_response(&mut rx).await;
+        assert!(
+            first.get("streamEvent").is_some()
+                || first.get("streamEnd").is_some()
+                || first.get("error").is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_spawn_streaming_call_error() {
+        let (state, tx, mut rx) = make_state(MockHandler::failing());
+        let req = WebSocketRequestEnvelope::new(
+            JsonRpcId::String("s2".into()),
+            methods::SEND_STREAMING_MESSAGE,
+            Some(typed_params(&message_request())),
+            None,
+        );
+        spawn_streaming_call(&state, ServiceParams::new(), req, tx);
+        let val = recv_response(&mut rx).await;
+        assert!(val["error"].is_object());
+    }
+
+    #[test]
+    fn test_invalid_params_error() {
+        let error = invalid_params_error("bad param");
+        assert_eq!(error.code, error_code::INVALID_PARAMS);
+        assert!(error.message.contains("bad param"));
+    }
+}

--- a/a2a/src/lib.rs
+++ b/a2a/src/lib.rs
@@ -7,12 +7,14 @@ pub mod errors;
 pub mod event;
 pub mod jsonrpc;
 pub mod types;
+pub mod websocket;
 
 pub use agent_card::*;
 pub use errors::*;
 pub use event::*;
 pub use jsonrpc::*;
 pub use types::*;
+pub use websocket::*;
 
 /// The A2A protocol version this SDK implements.
 pub const VERSION: &str = "1.0";

--- a/a2a/src/types.rs
+++ b/a2a/src/types.rs
@@ -704,6 +704,8 @@ pub const TRANSPORT_PROTOCOL_GRPC: &str = "GRPC";
 pub const TRANSPORT_PROTOCOL_HTTP_JSON: &str = "HTTP+JSON";
 /// SLIMRPC transport protocol constant.
 pub const TRANSPORT_PROTOCOL_SLIMRPC: &str = "SLIMRPC";
+/// WebSocket transport protocol constant.
+pub const TRANSPORT_PROTOCOL_WEBSOCKET: &str = "WEBSOCKET";
 
 /// Protocol version string (e.g., "1.0").
 pub type ProtocolVersion = String;

--- a/a2a/src/websocket.rs
+++ b/a2a/src/websocket.rs
@@ -1,0 +1,216 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+use crate::{JsonRpcError, JsonRpcId};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Message metadata propagated as service parameters.
+pub type WebSocketServiceParams = HashMap<String, Vec<String>>;
+
+/// Client-to-server WebSocket frame shape.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebSocketRequestEnvelope {
+    pub jsonrpc: String,
+    pub id: JsonRpcId,
+    pub method: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub params: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_params: Option<WebSocketServiceParams>,
+}
+
+impl WebSocketRequestEnvelope {
+    pub fn new(
+        id: JsonRpcId,
+        method: impl Into<String>,
+        params: Option<Value>,
+        service_params: Option<WebSocketServiceParams>,
+    ) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            method: method.into(),
+            params,
+            service_params,
+        }
+    }
+}
+
+/// Server-to-client WebSocket frame shape.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WebSocketResponseEnvelope {
+    pub jsonrpc: String,
+    pub id: JsonRpcId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_event: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_error: Option<JsonRpcError>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_end: Option<bool>,
+}
+
+impl WebSocketResponseEnvelope {
+    pub fn success(id: JsonRpcId, result: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: Some(result),
+            error: None,
+            stream_event: None,
+            stream_error: None,
+            stream_end: None,
+        }
+    }
+
+    pub fn error(id: JsonRpcId, error: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: Some(error),
+            stream_event: None,
+            stream_error: None,
+            stream_end: None,
+        }
+    }
+
+    pub fn stream_event(id: JsonRpcId, stream_event: Value) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: None,
+            stream_event: Some(stream_event),
+            stream_error: None,
+            stream_end: None,
+        }
+    }
+
+    pub fn stream_error(id: JsonRpcId, stream_error: JsonRpcError) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: None,
+            stream_event: None,
+            stream_error: Some(stream_error),
+            stream_end: None,
+        }
+    }
+
+    pub fn stream_end(id: JsonRpcId) -> Self {
+        Self {
+            jsonrpc: "2.0".to_string(),
+            id,
+            result: None,
+            error: None,
+            stream_event: None,
+            stream_error: None,
+            stream_end: Some(true),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jsonrpc::JsonRpcId;
+    use serde_json::json;
+
+    #[test]
+    fn test_websocket_request_envelope_serialization() {
+        let envelope = WebSocketRequestEnvelope::new(
+            JsonRpcId::String("test-id".into()),
+            "test_method",
+            Some(json!({"key": "value"})),
+            None,
+        );
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: WebSocketRequestEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.jsonrpc, "2.0");
+        assert_eq!(parsed.id, JsonRpcId::String("test-id".into()));
+        assert_eq!(parsed.method, "test_method");
+    }
+
+    #[test]
+    fn test_websocket_request_envelope_with_service_params() {
+        let mut params = WebSocketServiceParams::new();
+        params.insert("x-custom".to_string(), vec!["value".to_string()]);
+        let envelope = WebSocketRequestEnvelope::new(
+            JsonRpcId::String("id".into()),
+            "method",
+            None,
+            Some(params),
+        );
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: WebSocketRequestEnvelope = serde_json::from_str(&json).unwrap();
+        assert!(parsed.service_params.is_some());
+    }
+
+    #[test]
+    fn test_websocket_response_envelope_success() {
+        let envelope = WebSocketResponseEnvelope::success(
+            JsonRpcId::String("id".into()),
+            json!({"result": "ok"}),
+        );
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: WebSocketResponseEnvelope = serde_json::from_str(&json).unwrap();
+        assert!(parsed.result.is_some());
+        assert!(parsed.error.is_none());
+    }
+
+    #[test]
+    fn test_websocket_response_envelope_error() {
+        let error = JsonRpcError {
+            code: -32700,
+            message: "Parse error".to_string(),
+            data: None,
+        };
+        let envelope = WebSocketResponseEnvelope::error(JsonRpcId::String("id".into()), error);
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: WebSocketResponseEnvelope = serde_json::from_str(&json).unwrap();
+        assert!(parsed.error.is_some());
+        assert!(parsed.result.is_none());
+    }
+
+    #[test]
+    fn test_websocket_response_envelope_stream_event() {
+        let envelope = WebSocketResponseEnvelope::stream_event(
+            JsonRpcId::String("id".into()),
+            json!({"event": "data"}),
+        );
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: WebSocketResponseEnvelope = serde_json::from_str(&json).unwrap();
+        assert!(parsed.stream_event.is_some());
+        assert!(parsed.stream_error.is_none());
+    }
+
+    #[test]
+    fn test_websocket_response_envelope_stream_error() {
+        let error = JsonRpcError {
+            code: -32000,
+            message: "Stream error".to_string(),
+            data: None,
+        };
+        let envelope =
+            WebSocketResponseEnvelope::stream_error(JsonRpcId::String("id".into()), error);
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: WebSocketResponseEnvelope = serde_json::from_str(&json).unwrap();
+        assert!(parsed.stream_error.is_some());
+    }
+
+    #[test]
+    fn test_websocket_response_envelope_stream_end() {
+        let envelope = WebSocketResponseEnvelope::stream_end(JsonRpcId::String("id".into()));
+        let json = serde_json::to_string(&envelope).unwrap();
+        let parsed: WebSocketResponseEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.stream_end, Some(true));
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -49,3 +49,4 @@ rcgen = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+tokio-tungstenite = { workspace = true }

--- a/examples/src/helloworld/server.rs
+++ b/examples/src/helloworld/server.rs
@@ -32,6 +32,7 @@ async fn main() {
     let agent_card = build_agent_card(vec![
         AgentInterface::new("http://localhost:3000/jsonrpc", TRANSPORT_PROTOCOL_JSONRPC),
         AgentInterface::new("http://localhost:3000/rest", TRANSPORT_PROTOCOL_HTTP_JSON),
+        AgentInterface::new("ws://localhost:3000/ws", TRANSPORT_PROTOCOL_WEBSOCKET),
         AgentInterface::new("http://localhost:50051", TRANSPORT_PROTOCOL_GRPC),
     ]);
     let card_producer = Arc::new(StaticAgentCard::new(agent_card));
@@ -42,6 +43,10 @@ async fn main() {
             a2a_server::jsonrpc::jsonrpc_router(handler.clone()),
         )
         .nest("/rest", a2a_server::rest::rest_router(handler.clone()))
+        .nest(
+            "/ws",
+            a2a_server::websocket::websocket_router(handler.clone()),
+        )
         .merge(a2a_server::agent_card::agent_card_router(card_producer));
 
     let grpc_service = A2aServiceServer::new(GrpcHandler::new(handler));
@@ -50,6 +55,7 @@ async fn main() {
     tracing::info!("Agent card:  http://localhost:3000/.well-known/agent-card.json");
     tracing::info!("JSON-RPC:    http://localhost:3000/jsonrpc");
     tracing::info!("REST:        http://localhost:3000/rest");
+    tracing::info!("WebSocket:   ws://localhost:3000/ws");
     tracing::info!("gRPC:        http://localhost:50051");
 
     let http_listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();

--- a/examples/tests/transports_e2e.rs
+++ b/examples/tests/transports_e2e.rs
@@ -9,8 +9,10 @@ use a2a_client::Transport;
 use a2a_client::agent_card::AgentCardResolver;
 use a2a_client::jsonrpc::JsonRpcTransport;
 use a2a_client::rest::RestTransport;
+use a2a_client::websocket::WebSocketTransport;
 use a2a_server::jsonrpc::jsonrpc_router;
 use a2a_server::rest::rest_router;
+use a2a_server::websocket::websocket_router;
 use a2a_server::{
     DefaultRequestHandler, ExecutorContext, HttpPushSender, InMemoryPushConfigStore,
     InMemoryTaskStore, RequestHandler, ServiceParams, WELL_KNOWN_AGENT_CARD_PATH,
@@ -21,8 +23,8 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::routing::{get, post};
 use axum::{Json, Router};
-use futures::StreamExt;
 use futures::stream::{self, BoxStream};
+use futures::{SinkExt, StreamExt};
 use reqwest::Client;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
@@ -80,6 +82,7 @@ fn sample_agent_card() -> AgentCard {
         supported_interfaces: vec![
             AgentInterface::new("http://localhost/rest", TRANSPORT_PROTOCOL_HTTP_JSON),
             AgentInterface::new("http://localhost/rpc", TRANSPORT_PROTOCOL_JSONRPC),
+            AgentInterface::new("ws://localhost/ws", TRANSPORT_PROTOCOL_WEBSOCKET),
         ],
         capabilities: AgentCapabilities::default(),
         default_input_modes: vec!["text/plain".to_string()],
@@ -144,11 +147,14 @@ impl RequestHandler for TestHandler {
 
     async fn get_task(
         &self,
-        _params: &ServiceParams,
+        params: &ServiceParams,
         req: GetTaskRequest,
     ) -> Result<Task, A2AError> {
         if req.id == "missing" {
             return Err(A2AError::task_not_found(&req.id));
+        }
+        if let Some(task_id) = params.get("x-task-id").and_then(|values| values.first()) {
+            return Ok(sample_task(task_id, TaskState::Completed));
         }
         Ok(sample_task(&req.id, TaskState::Completed))
     }
@@ -322,7 +328,8 @@ async fn spawn_http_server() -> (String, tokio::task::JoinHandle<()>) {
     let handler = Arc::new(TestHandler);
     let app = Router::new()
         .nest("/rest", rest_router(handler.clone()))
-        .nest("/rpc", jsonrpc_router(handler))
+        .nest("/rpc", jsonrpc_router(handler.clone()))
+        .nest("/ws", websocket_router(handler))
         .route(
             WELL_KNOWN_AGENT_CARD_PATH,
             get(|| async { Json(sample_agent_card()) }),
@@ -352,7 +359,8 @@ async fn spawn_push_http_server() -> (String, tokio::task::JoinHandle<()>) {
     );
     let app = Router::new()
         .nest("/rest", rest_router(handler.clone()))
-        .nest("/rpc", jsonrpc_router(handler))
+        .nest("/rpc", jsonrpc_router(handler.clone()))
+        .nest("/ws", websocket_router(handler))
         .route(
             WELL_KNOWN_AGENT_CARD_PATH,
             get(|| async { Json(sample_agent_card()) }),
@@ -959,4 +967,120 @@ async fn jsonrpc_transport_push_delivery_end_to_end() {
 
     server_handle.abort();
     webhook_handle.abort();
+}
+
+#[tokio::test]
+async fn websocket_transport_end_to_end() {
+    let (base_url, handle) = spawn_http_server().await;
+    let ws_url = base_url.replacen("http://", "ws://", 1);
+    let transport = WebSocketTransport::connect(&format!("{ws_url}/ws"))
+        .await
+        .unwrap();
+
+    let send_resp = transport
+        .send_message(&ServiceParams::new(), &send_message_request())
+        .await;
+    assert!(matches!(send_resp.unwrap(), SendMessageResponse::Task(_)));
+
+    let stream = transport
+        .send_streaming_message(&ServiceParams::new(), &send_message_request())
+        .await
+        .unwrap();
+    let items: Vec<_> = stream.collect().await;
+    assert_eq!(items.len(), 2);
+
+    let task = transport
+        .get_task(
+            &ServiceParams::new(),
+            &GetTaskRequest {
+                id: "task-1".to_string(),
+                history_length: Some(2),
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(task.id, "task-1");
+
+    let not_found = transport
+        .get_task(
+            &ServiceParams::new(),
+            &GetTaskRequest {
+                id: "missing".to_string(),
+                history_length: None,
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap_err();
+    assert_eq!(not_found.code, error_code::TASK_NOT_FOUND);
+
+    let subscribed = transport
+        .subscribe_to_task(
+            &ServiceParams::new(),
+            &SubscribeToTaskRequest {
+                id: "task-1".to_string(),
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap();
+    let events: Vec<_> = subscribed.collect().await;
+    assert_eq!(events.len(), 1);
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn websocket_transport_propagates_message_service_params() {
+    let (base_url, handle) = spawn_http_server().await;
+    let ws_url = base_url.replacen("http://", "ws://", 1);
+    let transport = WebSocketTransport::connect(&format!("{ws_url}/ws"))
+        .await
+        .unwrap();
+    let mut params = ServiceParams::new();
+    params.insert(
+        "x-task-id".to_string(),
+        vec!["task-from-params".to_string()],
+    );
+
+    let task = transport
+        .get_task(
+            &params,
+            &GetTaskRequest {
+                id: "task-from-request".to_string(),
+                history_length: None,
+                tenant: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(task.id, "task-from-params");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn websocket_transport_reports_malformed_frame() {
+    let (base_url, handle) = spawn_http_server().await;
+    let ws_url = base_url.replacen("http://", "ws://", 1);
+    let (mut socket, _) = tokio_tungstenite::connect_async(format!("{ws_url}/ws"))
+        .await
+        .unwrap();
+
+    socket
+        .send(tokio_tungstenite::tungstenite::Message::Text(
+            "not-json".to_string(),
+        ))
+        .await
+        .unwrap();
+    let response = socket.next().await.unwrap().unwrap();
+    let text = response.into_text().unwrap();
+    let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+    assert_eq!(value["jsonrpc"], "2.0");
+    assert_eq!(value["id"], serde_json::Value::Null);
+    assert_eq!(value["error"]["code"], error_code::PARSE_ERROR);
+
+    handle.abort();
 }


### PR DESCRIPTION
# WebSocket Transport Binding - Change Summary

## Goal

Goal of the PR to create alignment on direction and implementation. **NOT READY FOR MERGE**. See #14 for discussion. 

## Overview

Add WebSocket transport binding so the workspace supports a bidirectional A2A transport alongside the existing JSON-RPC over HTTP, REST / HTTP+JSON, gRPC, and SSE streaming support.

**Refs:** #14  
**Parent Feature:** #12

## Changes Mapped to Task Scope

### 1. Add a WebSocket protocol identifier and agent-card negotiation path

- **`a2a/src/types.rs`**
  - Added `TRANSPORT_PROTOCOL_WEBSOCKET` constant (`"WEBSOCKET"`)

- **`a2a/src/lib.rs`**
  - Exported `websocket` module

- **`examples/src/helloworld/server.rs`**
  - Added WebSocket interface to agent card:
    - `AgentInterface::new("ws://localhost:3000/ws", TRANSPORT_PROTOCOL_WEBSOCKET)`

- **`a2a-client/src/factory.rs`**
  - Registered `WebSocketTransportFactory` in `A2AClientFactoryBuilder::build()` when `include_defaults` is true
  - Default preference order remains JSON-RPC → HTTP+JSON → WebSocket (preserves existing behavior)
  - Added negotiation tests:
    - `test_create_from_card_selects_websocket_when_only_match` - verifies WebSocket selected when only compatible binding
    - `test_create_from_card_honors_websocket_preference` - verifies `preferred_bindings` can prioritize WebSocket

### 2. Implement a client transport and register it in the client transport/factory layer

- **`a2a-client/src/websocket.rs`** (new file)
  - Implemented `WebSocketTransport` with `Transport` trait
    - Supports all unary and streaming A2A operations
    - Uses UUID v7 string IDs for request correlation
    - Manages pending unary and streaming calls via `Arc<Mutex<HashMap>>`
    - Handles connection close and protocol errors with `fail_all_pending()`
  - Implemented `WebSocketTransportFactory` with `TransportFactory` trait
    - Validates `ws://` or `wss://` URLs
    - Returns `WebSocketTransport` instances
  - Added `Default` impl for `WebSocketTransportFactory`

- **`a2a-client/src/lib.rs`**
  - Exported `websocket` module

### 3. Implement server wrapper(s) that translate framed WebSocket messages into RequestHandler operations

- **`a2a-server/src/websocket.rs`** (new file)
  - Implemented `websocket_router()` to mount WebSocket upgrade handler
  - Implemented `handle_websocket()` to extract connection-level `ServiceParams` from headers
  - Implemented `serve_socket()` to manage bidirectional WebSocket communication
    - Rejects binary frames with close code `UNSUPPORTED`
    - Routes text frames through `handle_text_frame()`
    - Handles connection close gracefully
  - Implemented `handle_text_frame()` to:
    - Parse `WebSocketRequestEnvelope`
    - Validate `jsonrpc` version
    - Merge connection-level and per-message `ServiceParams`
    - Dispatch unary calls via `handle_unary_request()`
    - Dispatch streaming calls via `spawn_streaming_call()`
  - Implemented `spawn_streaming_call()` for streaming methods:
    - `send_streaming_message`
    - `subscribe_to_task`
    - Sends `stream_event` frames for each stream item
    - Sends `stream_error` on failure
    - Sends `stream_end` on completion
  - Implemented `handle_unary_request()` for unary methods:
    - `send_message`, `get_task`, `list_tasks`, `cancel_task`
    - Push config operations: `create_push_config`, `get_push_config`, `list_push_configs`, `delete_push_config`
    - `get_extended_agent_card`
  - Helper functions: `send_response()`, `service_params_from_headers()`, `protojson_value()`, `parse_create_push_config_request()`, `parse_error()`
  - Changed `service_params_from_headers()` to use `or_default()` instead of `or_insert_with(Vec::new())`

- **`a2a-server/src/lib.rs`**
  - Exported `websocket` module

- **`examples/src/helloworld/server.rs`**
  - Mounted WebSocket router:
    - `.nest("/ws", a2a_server::websocket::websocket_router(handler.clone()))`
  - Added logging for WebSocket endpoint

### 4. Define framing rules, request correlation, and streaming event shapes over a bidirectional connection

- **`a2a/src/websocket.rs`** (new file)
  - Added `WebSocketRequestEnvelope` for client-to-server frames
    - Fields: `jsonrpc`, `id`, `method`, `params`, `service_params`
  - Added `WebSocketResponseEnvelope` for server-to-client frames
    - Fields: `jsonrpc`, `id`, `result`, `error`, `stream_event`, `stream_error`, `stream_end`
  - Helper constructors: `success()`, `error()`, `stream_event()`, `stream_error()`, `stream_end()`
  - Defines framing rules for unary and streaming operations over a single WebSocket connection

- **`a2a-client/src/websocket.rs`**
  - Uses UUID v7 string IDs for request correlation
  - Routes incoming frames to pending unary/streaming calls via ID lookup

- **`README.md`**
  - Added "WebSocket binding" section documenting:
    - Frame correlation via string `id`
    - Response frame types: `result`, `error`, `stream_event`, `stream_error`, `streamEnd`
    - Streaming behavior: zero or more `streamEvent` followed by `streamEnd` or `streamError`

### 5. Define ServiceParams propagation during connection setup and per-message metadata handling

- **`a2a-server/src/websocket.rs`**
  - `service_params_from_headers()` extracts connection-level params from HTTP headers
  - `handle_text_frame()` merges connection-level and per-message `service_params` before dispatch
  - `service_params_from_headers()` uses `or_default()` for cleaner code

- **`a2a-client/src/websocket.rs`**
  - `WebSocketRequestEnvelope` includes optional `service_params` field
  - Client sends per-message `service_params` when non-empty

- **`examples/tests/transports_e2e.rs`**
  - Added `websocket_transport_propagates_message_service_params` test:
    - Verifies per-message `ServiceParams` override request params
    - Modified `TestHandler::get_task` to check `x-task-id` parameter

- **`README.md`**
  - Documented Service params propagation: connection headers + per-message merge

### 6. Define A2AError mapping for protocol violations, close conditions, and operation failures

- **`a2a-client/src/websocket.rs`**
  - Connection errors mapped to `A2AError::invalid_request()` (invalid URL)
  - Connection errors mapped to `A2AError::internal()` (connect failure)
  - Frame serialization errors mapped to `A2AError::internal()`
  - Channel closure errors mapped to `A2AError::unsupported_operation()`
  - `fail_all_pending()` propagates connection-level errors to all pending calls
  - `route_incoming_frame()` maps parse errors to `A2AError::parse_error()`
  - `route_incoming_frame()` maps non-string IDs to `A2AError::invalid_request()`

- **`a2a-server/src/websocket.rs`**
  - Invalid JSON frames mapped to `parse_error` JSON-RPC error (code -32700)
  - Invalid `jsonrpc` version mapped to `invalid_request` JSON-RPC error
  - Binary frames rejected with `UNSUPPORTED` close code
  - ProtoJSON serialization errors mapped to `A2AError::internal()`
  - `parse_error()` helper constructs `A2AError` with `PARSE_ERROR` code

- **`examples/tests/transports_e2e.rs`**
  - Added `websocket_transport_reports_malformed_frame` test:
    - Sends malformed JSON frame
    - Verifies server responds with `PARSE_ERROR` JSON-RPC error

### 7. Extend the helloworld transport end-to-end coverage and supporting docs as needed

- **`examples/tests/transports_e2e.rs`**
  - Added `websocket_transport_end_to_end` test:
    - Verifies unary `send_message` works
    - Verifies streaming `send_streaming_message` returns 2 events
    - Verifies `get_task` returns expected task
    - Verifies `get_task` with missing ID returns `TASK_NOT_FOUND` error
    - Verifies `subscribe_to_task` returns 1 event
  - Added `websocket_transport_propagates_message_service_params` test (ServiceParams coverage)
  - Added `websocket_transport_reports_malformed_frame` test (protocol-error coverage)
  - Added `tokio_tungstenite` import for low-level WebSocket test

- **`examples/Cargo.toml`**
  - Added `tokio-tungstenite` as dev-dependency for WebSocket e2e tests

- **`README.md`**
  - Added WebSocket to supported bindings list
  - Added "WebSocket binding" section with:
    - Agent-card advertisement with `WEBSOCKET` protocol binding
    - Default factory registration and preference order
    - Frame correlation, response frame types, streaming behavior
    - Service params propagation
  - Updated client usage description to include WebSocket

### Dependencies

- **`Cargo.lock`**
  - Updated to reflect `tokio-tungstenite` addition in examples dev-dependencies

## Acceptance Criteria Status

- ✅ Agent cards can advertise WebSocket and the client factory can negotiate it without regressing existing binding selection
- ✅ Unary and streaming operations work over a single documented bidirectional connection
- ✅ Framing, request correlation, metadata propagation, and A2AError mapping are covered by tests
- ✅ End-to-end coverage includes happy-path flows and at least one close or protocol-error path (malformed frame test)

## Validation

- **Formatting:** Passed (`cargo fmt --all -- --check`)
- **Targeted tests:** Passed (`cargo test -p a2a-client-lf -p examples websocket --all-features`)
  - 2 factory WebSocket negotiation tests passed
  - 3 WebSocket e2e tests passed
- **Workspace check:** Passed (`cargo check --workspace --all-features`)

## Files Changed

- `a2a/src/lib.rs`
- `a2a/src/types.rs`
- `a2a/src/websocket.rs` (new)
- `a2a-client/src/lib.rs`
- `a2a-client/src/factory.rs`
- `a2a-client/src/websocket.rs` (new)
- `a2a-server/src/lib.rs`
- `a2a-server/src/websocket.rs` (new)
- `examples/src/helloworld/server.rs`
- `examples/tests/transports_e2e.rs`
- `examples/Cargo.toml`
- `Cargo.lock`
- `README.md`

