### PR TITLE
fix(a2a-client): unify reqwest TLS construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "uuid",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/a2a-client/Cargo.toml
+++ b/a2a-client/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "a2a-client-lf"
 version = "0.1.16"
@@ -27,12 +30,33 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 semver = { workspace = true }
 pin-project-lite = { workspace = true }
-rustls = { workspace = true, optional = true, features = ["aws-lc-rs"] }
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { version = "2", optional = true }
+webpki-roots = { version = "1", optional = true }
 
 [dev-dependencies]
 rcgen = { workspace = true }
 
 [features]
-default = ["rustls-tls"]
+# By default we will use aws-lc-rs as crypto provider.
+default = ["rustls-tls-aws-lc-rs"]
+
+# For application setting their own provider, we use rustls
+# with NO crypto provider compiled in.
+# Consumers selecting only this feature are responsible for installing a
+# process-wide `CryptoProvider` (via `install_default()`) in their
+# main function. If they don't do it, `reqwest::Client::new()` will panic with
+# "no process-level CryptoProvider available".
+rustls-tls = [
+    "reqwest/rustls-tls-webpki-roots-no-provider",
+    "dep:rustls",
+    "dep:rustls-pemfile",
+    "dep:webpki-roots",
+]
+
+# If the consumer wants, a2a-client can also pull in a crypto provider and use it
+# when creating the reqwest client.
+rustls-tls-aws-lc-rs = ["rustls-tls", "rustls/aws-lc-rs"]
+rustls-tls-ring = ["rustls-tls", "rustls/ring"]
+
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls-webpki-roots-no-provider", "dep:rustls"]

--- a/a2a-client/src/agent_card.rs
+++ b/a2a-client/src/agent_card.rs
@@ -11,7 +11,8 @@ pub struct AgentCardResolver {
 impl AgentCardResolver {
     pub fn new(client: Option<Client>) -> Self {
         AgentCardResolver {
-            client: client.unwrap_or_default(),
+            client: client
+                .unwrap_or_else(|| crate::default_reqwest_client(None).expect("default client")),
         }
     }
 

--- a/a2a-client/src/jsonrpc.rs
+++ b/a2a-client/src/jsonrpc.rs
@@ -43,6 +43,7 @@ pub struct JsonRpcTransport {
 }
 
 impl JsonRpcTransport {
+    /// Build a `JsonRpcTransport` from a pre-constructed `reqwest::Client`.
     pub fn new(client: Client, endpoint: String) -> Self {
         JsonRpcTransport { client, endpoint }
     }
@@ -458,14 +459,15 @@ pub struct JsonRpcTransportFactory {
 impl JsonRpcTransportFactory {
     pub fn new(client: Option<Client>) -> Self {
         JsonRpcTransportFactory {
-            client: client.unwrap_or_default(),
+            client: client
+                .unwrap_or_else(|| crate::default_reqwest_client(None).expect("default client")),
         }
     }
 
     #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
     pub fn with_root_certificates_pem(pem: &[u8]) -> Result<Self, A2AError> {
         Ok(Self {
-            client: crate::build_reqwest_client_with_root_pem(pem)?,
+            client: crate::default_reqwest_client(Some(pem))?,
         })
     }
 }
@@ -1014,7 +1016,10 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
-        let err = reqwest::get(format!("http://{addr}/"))
+        let err = crate::default_reqwest_client(None)
+            .unwrap()
+            .get(format!("http://{addr}/"))
+            .send()
             .await
             .expect_err("connection should fail");
 
@@ -1034,7 +1039,10 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         drop(listener);
-        let err = reqwest::get(format!("http://{addr}/"))
+        let err = crate::default_reqwest_client(None)
+            .unwrap()
+            .get(format!("http://{addr}/"))
+            .send()
             .await
             .expect_err("connection should fail");
 
@@ -1117,7 +1125,10 @@ mod tests {
 
     #[test]
     fn test_jsonrpc_transport_new() {
-        let t = JsonRpcTransport::new(Client::new(), "http://localhost:8080".into());
+        let t = JsonRpcTransport::new(
+            crate::default_reqwest_client(None).unwrap(),
+            "http://localhost:8080".into(),
+        );
         assert_eq!(t.endpoint, "http://localhost:8080");
     }
 
@@ -1171,7 +1182,8 @@ mod tests {
         })
         .to_string();
         let (endpoint, request_rx) = spawn_jsonrpc_server(response).await;
-        let transport = JsonRpcTransport::new(Client::new(), endpoint);
+        let transport =
+            JsonRpcTransport::new(crate::default_reqwest_client(None).unwrap(), endpoint);
         let mut params = ServiceParams::new();
         params.insert("x-trace".into(), vec!["alpha".into(), "beta".into()]);
 
@@ -1220,7 +1232,8 @@ mod tests {
         })
         .to_string();
         let (endpoint, _request_rx) = spawn_jsonrpc_server(response).await;
-        let transport = JsonRpcTransport::new(Client::new(), endpoint);
+        let transport =
+            JsonRpcTransport::new(crate::default_reqwest_client(None).unwrap(), endpoint);
 
         let error = transport
             .create_push_config(&ServiceParams::new(), &sample_create_push_config_request())
@@ -1239,7 +1252,8 @@ mod tests {
         })
         .to_string();
         let (endpoint, _request_rx) = spawn_jsonrpc_server(response).await;
-        let transport = JsonRpcTransport::new(Client::new(), endpoint);
+        let transport =
+            JsonRpcTransport::new(crate::default_reqwest_client(None).unwrap(), endpoint);
 
         let error = transport
             .create_push_config(&ServiceParams::new(), &sample_create_push_config_request())
@@ -1265,7 +1279,8 @@ mod tests {
         })
         .to_string();
         let (endpoint, request_rx) = spawn_jsonrpc_server(response).await;
-        let transport = JsonRpcTransport::new(Client::new(), endpoint);
+        let transport =
+            JsonRpcTransport::new(crate::default_reqwest_client(None).unwrap(), endpoint);
 
         let result = transport
             .get_push_config(

--- a/a2a-client/src/lib.rs
+++ b/a2a-client/src/lib.rs
@@ -15,6 +15,78 @@ pub use factory::A2AClientFactory;
 pub use futures::stream::BoxStream;
 pub use transport::{ServiceParams, Transport, TransportFactory};
 
+/// Build a `reqwest::Client` whose TLS layer matches this crate's feature
+/// selection, optionally adding extra root certificates from a PEM bundle.
+///
+/// - When `rustls-tls-aws-lc-rs` or `rustls-tls-ring` is enabled, a
+///   `rustls::ClientConfig` is constructed with the corresponding provider
+///   and handed to `reqwest::ClientBuilder::use_preconfigured_tls`. Custom
+///   PEM certificates are parsed and added to the rustls root store
+///   alongside the webpki roots. No process-global `CryptoProvider` is
+///   installed.
+/// - When only `rustls-tls` is enabled (no provider variant), reqwest
+///   falls back to whatever `CryptoProvider` the application installed via
+///   `install_default()`. If none is installed, `reqwest::Client::new()`
+///   panics; that is the contract the consumer accepted by disabling the
+///   provider variants.
+/// - When the rustls features are off (e.g. only `native-tls`), extra
+///   certificates are added via `reqwest::ClientBuilder::add_root_certificate`.
+pub fn default_reqwest_client(
+    extra_root_pem: Option<&[u8]>,
+) -> Result<reqwest::Client, a2a::A2AError> {
+    let builder = reqwest::Client::builder();
+
+    #[cfg(any(feature = "rustls-tls-aws-lc-rs", feature = "rustls-tls-ring"))]
+    let builder = builder.use_preconfigured_tls(rustls_client_config(extra_root_pem)?);
+
+    #[cfg(not(any(feature = "rustls-tls-aws-lc-rs", feature = "rustls-tls-ring")))]
+    let builder = match extra_root_pem {
+        Some(pem) => {
+            let cert = reqwest::Certificate::from_pem(pem)
+                .map_err(|e| a2a::A2AError::internal(format!("invalid PEM certificate: {e}")))?;
+            builder.add_root_certificate(cert)
+        }
+        None => builder,
+    };
+
+    builder
+        .build()
+        .map_err(|e| a2a::A2AError::internal(format!("failed to build HTTP client: {e}")))
+}
+
+#[cfg(any(feature = "rustls-tls-aws-lc-rs", feature = "rustls-tls-ring"))]
+fn rustls_client_config(
+    extra_root_pem: Option<&[u8]>,
+) -> Result<rustls::ClientConfig, a2a::A2AError> {
+    let provider = std::sync::Arc::new(selected_crypto_provider());
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    if let Some(pem) = extra_root_pem {
+        for cert in rustls_pemfile::certs(&mut std::io::Cursor::new(pem)) {
+            let der =
+                cert.map_err(|e| a2a::A2AError::internal(format!("invalid PEM certificate: {e}")))?;
+            roots
+                .add(der)
+                .map_err(|e| a2a::A2AError::internal(format!("failed to add CA: {e}")))?;
+        }
+    }
+    Ok(rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .expect("safe default protocol versions are supported")
+        .with_root_certificates(roots)
+        .with_no_client_auth())
+}
+
+#[cfg(feature = "rustls-tls-aws-lc-rs")]
+fn selected_crypto_provider() -> rustls::crypto::CryptoProvider {
+    rustls::crypto::aws_lc_rs::default_provider()
+}
+
+#[cfg(all(feature = "rustls-tls-ring", not(feature = "rustls-tls-aws-lc-rs")))]
+fn selected_crypto_provider() -> rustls::crypto::CryptoProvider {
+    rustls::crypto::ring::default_provider()
+}
+
 pub(crate) fn a2a_error_from_details(
     code: i32,
     message: String,
@@ -70,18 +142,6 @@ pub(crate) fn a2a_error_from_details(
         message,
         details: (!details.is_empty()).then_some(details),
     }
-}
-
-#[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
-pub(crate) fn build_reqwest_client_with_root_pem(
-    pem: &[u8],
-) -> Result<reqwest::Client, a2a::A2AError> {
-    let cert = reqwest::Certificate::from_pem(pem)
-        .map_err(|e| a2a::A2AError::internal(format!("invalid PEM certificate: {e}")))?;
-    reqwest::Client::builder()
-        .add_root_certificate(cert)
-        .build()
-        .map_err(|e| a2a::A2AError::internal(format!("failed to build HTTP client: {e}")))
 }
 
 #[cfg(test)]

--- a/a2a-client/src/rest.rs
+++ b/a2a-client/src/rest.rs
@@ -40,6 +40,7 @@ pub struct RestTransport {
 }
 
 impl RestTransport {
+    /// Build a `RestTransport` from a pre-constructed `reqwest::Client`.
     pub fn new(client: Client, base_url: String) -> Self {
         let base_url = base_url.trim_end_matches('/').to_string();
         RestTransport { client, base_url }
@@ -416,14 +417,15 @@ pub struct RestTransportFactory {
 impl RestTransportFactory {
     pub fn new(client: Option<Client>) -> Self {
         RestTransportFactory {
-            client: client.unwrap_or_default(),
+            client: client
+                .unwrap_or_else(|| crate::default_reqwest_client(None).expect("default client")),
         }
     }
 
     #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
     pub fn with_root_certificates_pem(pem: &[u8]) -> Result<Self, A2AError> {
         Ok(Self {
-            client: crate::build_reqwest_client_with_root_pem(pem)?,
+            client: crate::default_reqwest_client(Some(pem))?,
         })
     }
 }
@@ -454,13 +456,19 @@ mod tests {
 
     #[test]
     fn test_rest_transport_new_strips_trailing_slash() {
-        let t = RestTransport::new(Client::new(), "http://localhost:8080/".into());
+        let t = RestTransport::new(
+            crate::default_reqwest_client(None).unwrap(),
+            "http://localhost:8080/".into(),
+        );
         assert_eq!(t.base_url, "http://localhost:8080");
     }
 
     #[test]
     fn test_rest_transport_new_no_trailing_slash() {
-        let t = RestTransport::new(Client::new(), "http://localhost:8080".into());
+        let t = RestTransport::new(
+            crate::default_reqwest_client(None).unwrap(),
+            "http://localhost:8080".into(),
+        );
         assert_eq!(t.base_url, "http://localhost:8080");
     }
 
@@ -496,7 +504,10 @@ mod tests {
 
     #[test]
     fn test_build_request_adds_params() {
-        let t = RestTransport::new(Client::new(), "http://localhost:8080".into());
+        let t = RestTransport::new(
+            crate::default_reqwest_client(None).unwrap(),
+            "http://localhost:8080".into(),
+        );
         let mut params = ServiceParams::new();
         params.insert("X-Custom".into(), vec!["val1".into(), "val2".into()]);
         let builder = t.build_request(reqwest::Method::GET, "/test", &params);


### PR DESCRIPTION
## Summary

`a2a-client`'s rustls path had two problems:

1. **Panic on first use.** Enabling `rustls-tls` pulled reqwest's
   `rustls-tls-webpki-roots-no-provider`, which requires the consumer to
   register a rustls `CryptoProvider` at runtime. Without an
   `install_default()` call, the first `reqwest::Client::new()` panicked
   with `"No provider set"` under `rustls 0.23+`. `a2a-server` and
   `a2a-grpc` already installed `aws-lc-rs`; `a2a-client` was missed.
2. **Silently dropped custom roots.** Custom CA bundles passed via
   `with_root_certificates_pem()` were ignored whenever a rustls
   provider feature was active, because the client was built via the
   plain `reqwest::Client::builder()` path that never saw them.

Rather than installing a process-global `CryptoProvider` (which leaks
state into the host application and races with other crates), this PR
unifies all internal `reqwest::Client` construction behind a single
constructor that wires TLS per-client.

Fixes: #67 