### PR TITLE
fix(a2a-server): propagate HTTP headers into ServiceParams

### DIFF
--- a/a2a-server/src/jsonrpc.rs
+++ b/a2a-server/src/jsonrpc.rs
@@ -4,12 +4,17 @@ use std::sync::Arc;
 
 use a2a::*;
 use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+};
 use futures::{StreamExt, stream::BoxStream};
 use serde_json::Value;
 
 use crate::handler::RequestHandler;
-use crate::middleware::ServiceParams;
+use crate::middleware::{ServiceParams, extract_service_params};
 use crate::sse;
 
 /// Shared state for the JSON-RPC handler.
@@ -38,9 +43,10 @@ pub fn jsonrpc_router<H: RequestHandler>(handler: Arc<H>) -> axum::Router {
 
 async fn handle_jsonrpc<H: RequestHandler>(
     State(state): State<JsonRpcState<H>>,
+    headers: HeaderMap,
     Json(request): Json<JsonRpcRequest>,
 ) -> impl IntoResponse {
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     let id = request.id.clone();
     let method = request.method.as_str();
 
@@ -241,7 +247,7 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
 
-    use crate::test_util::install_crypto_provider;
+    use crate::test_util::{CapturingHandler, assert_header_captured, install_crypto_provider};
     use futures::stream::BoxStream;
     use http_body_util::BodyExt;
     use tower::ServiceExt;
@@ -579,6 +585,169 @@ mod tests {
             rpc_resp.result
         );
         assert_eq!(rpc_resp.error.unwrap().code, error_code::METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_send_message_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = jsonrpc_router(handler);
+
+        let rpc = JsonRpcRequest::new(
+            JsonRpcId::Number(1),
+            methods::SEND_MESSAGE,
+            Some(serde_json::json!({
+                "message": {
+                    "messageId": "m1",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "hi"}]
+                }
+            })),
+        );
+        let req = Request::builder()
+            .uri("/")
+            .method("POST")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer jsonrpc-token")
+            .header("x-tenant-id", "acme")
+            .body(Body::from(serde_json::to_string(&rpc).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        assert_header_captured(
+            &captured,
+            "send_message",
+            "authorization",
+            "Bearer jsonrpc-token",
+        );
+        assert_header_captured(&captured, "send_message", "x-tenant-id", "acme");
+    }
+
+    #[tokio::test]
+    async fn test_streaming_send_message_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = jsonrpc_router(handler);
+
+        let rpc = JsonRpcRequest::new(
+            JsonRpcId::Number(1),
+            methods::SEND_STREAMING_MESSAGE,
+            Some(serde_json::json!({
+                "message": {
+                    "messageId": "m1",
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "hi"}]
+                }
+            })),
+        );
+        let req = Request::builder()
+            .uri("/")
+            .method("POST")
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .header("authorization", "Bearer jsonrpc-streaming-token")
+            .header("x-tenant-id", "acme")
+            .body(Body::from(serde_json::to_string(&rpc).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        // Drain the SSE body so the handler is driven to completion.
+        let _ = resp.into_body().collect().await.unwrap().to_bytes();
+
+        assert_header_captured(
+            &captured,
+            "send_streaming_message",
+            "authorization",
+            "Bearer jsonrpc-streaming-token",
+        );
+        assert_header_captured(&captured, "send_streaming_message", "x-tenant-id", "acme");
+    }
+
+    #[tokio::test]
+    async fn test_jsonrpc_unary_methods_propagate_headers_as_service_params() {
+        // Exercise every unary JSON-RPC method to lock in header propagation
+        // across the full match arm in handle_unary_request.
+        let cases: &[(&'static str, &'static str, serde_json::Value)] = &[
+            (
+                methods::GET_TASK,
+                "get_task",
+                serde_json::json!({"id": "t1"}),
+            ),
+            (methods::LIST_TASKS, "list_tasks", serde_json::json!({})),
+            (
+                methods::CANCEL_TASK,
+                "cancel_task",
+                serde_json::json!({"id": "t1"}),
+            ),
+            (
+                methods::CREATE_PUSH_CONFIG,
+                "create_push_config",
+                serde_json::json!({"taskId": "t1", "url": "http://example.com/cb"}),
+            ),
+            (
+                methods::GET_PUSH_CONFIG,
+                "get_push_config",
+                serde_json::json!({"taskId": "t1", "id": "cfg1"}),
+            ),
+            (
+                methods::LIST_PUSH_CONFIGS,
+                "list_push_configs",
+                serde_json::json!({"taskId": "t1"}),
+            ),
+            (
+                methods::DELETE_PUSH_CONFIG,
+                "delete_push_config",
+                serde_json::json!({"taskId": "t1", "id": "cfg1"}),
+            ),
+            (
+                methods::GET_EXTENDED_AGENT_CARD,
+                "get_extended_agent_card",
+                serde_json::json!({}),
+            ),
+        ];
+
+        for (rpc_method, handler_method, params) in cases {
+            let (handler, captured) = CapturingHandler::new();
+            let app = jsonrpc_router(handler);
+            let rpc = JsonRpcRequest::new(JsonRpcId::Number(1), *rpc_method, Some(params.clone()));
+            let token = format!("Bearer token-for-{handler_method}");
+            let req = Request::builder()
+                .uri("/")
+                .method("POST")
+                .header("content-type", "application/json")
+                .header("authorization", &token)
+                .body(Body::from(serde_json::to_string(&rpc).unwrap()))
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_header_captured(&captured, handler_method, "authorization", &token);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_jsonrpc_subscribe_to_task_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = jsonrpc_router(handler);
+        let rpc = JsonRpcRequest::new(
+            JsonRpcId::Number(1),
+            methods::SUBSCRIBE_TO_TASK,
+            Some(serde_json::json!({"id": "t1"})),
+        );
+        let req = Request::builder()
+            .uri("/")
+            .method("POST")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer subscribe-token")
+            .body(Body::from(serde_json::to_string(&rpc).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let _ = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_header_captured(
+            &captured,
+            "subscribe_to_task",
+            "authorization",
+            "Bearer subscribe-token",
+        );
     }
 
     #[tokio::test]

--- a/a2a-server/src/lib.rs
+++ b/a2a-server/src/lib.rs
@@ -21,10 +21,175 @@ pub use task_store::{InMemoryTaskStore, TaskStore};
 
 #[cfg(test)]
 pub(crate) mod test_util {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use a2a::*;
+    use async_trait::async_trait;
+    use futures::stream::BoxStream;
+
+    use crate::handler::RequestHandler;
+    use crate::middleware::ServiceParams;
+
     pub fn install_crypto_provider() {
         #[cfg(feature = "rustls-tls")]
         {
             let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         }
+    }
+
+    pub(crate) type CapturedParams = Arc<Mutex<HashMap<&'static str, ServiceParams>>>;
+
+    /// `RequestHandler` stub that records the `ServiceParams` it sees per method.
+    ///
+    /// Used by transport-layer tests to assert that incoming request headers
+    /// are surfaced through to the `RequestHandler` boundary — which is exactly
+    /// what the HTTP / JSON-RPC transports are responsible for. Returns minimal
+    /// stub responses so tests don't depend on `DefaultRequestHandler` behavior.
+    pub(crate) struct CapturingHandler {
+        captured: CapturedParams,
+    }
+
+    impl CapturingHandler {
+        pub fn new() -> (Arc<Self>, CapturedParams) {
+            let captured = Arc::new(Mutex::new(HashMap::new()));
+            let handler = Arc::new(CapturingHandler {
+                captured: captured.clone(),
+            });
+            (handler, captured)
+        }
+
+        fn record(&self, method: &'static str, params: &ServiceParams) {
+            self.captured.lock().unwrap().insert(method, params.clone());
+        }
+    }
+
+    #[async_trait]
+    impl RequestHandler for CapturingHandler {
+        async fn send_message(
+            &self,
+            params: &ServiceParams,
+            _req: SendMessageRequest,
+        ) -> Result<SendMessageResponse, A2AError> {
+            self.record("send_message", params);
+            Err(A2AError::internal("stub"))
+        }
+
+        async fn send_streaming_message(
+            &self,
+            params: &ServiceParams,
+            _req: SendMessageRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            self.record("send_streaming_message", params);
+            Ok(Box::pin(futures::stream::empty()))
+        }
+
+        async fn get_task(
+            &self,
+            params: &ServiceParams,
+            _req: GetTaskRequest,
+        ) -> Result<Task, A2AError> {
+            self.record("get_task", params);
+            Err(A2AError::task_not_found("stub"))
+        }
+
+        async fn list_tasks(
+            &self,
+            params: &ServiceParams,
+            _req: ListTasksRequest,
+        ) -> Result<ListTasksResponse, A2AError> {
+            self.record("list_tasks", params);
+            Ok(ListTasksResponse {
+                tasks: Vec::new(),
+                next_page_token: String::new(),
+                page_size: 0,
+                total_size: 0,
+            })
+        }
+
+        async fn cancel_task(
+            &self,
+            params: &ServiceParams,
+            _req: CancelTaskRequest,
+        ) -> Result<Task, A2AError> {
+            self.record("cancel_task", params);
+            Err(A2AError::task_not_found("stub"))
+        }
+
+        async fn subscribe_to_task(
+            &self,
+            params: &ServiceParams,
+            _req: SubscribeToTaskRequest,
+        ) -> Result<BoxStream<'static, Result<StreamResponse, A2AError>>, A2AError> {
+            self.record("subscribe_to_task", params);
+            Ok(Box::pin(futures::stream::empty()))
+        }
+
+        async fn create_push_config(
+            &self,
+            params: &ServiceParams,
+            req: TaskPushNotificationConfig,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            self.record("create_push_config", params);
+            Ok(req)
+        }
+
+        async fn get_push_config(
+            &self,
+            params: &ServiceParams,
+            _req: GetTaskPushNotificationConfigRequest,
+        ) -> Result<TaskPushNotificationConfig, A2AError> {
+            self.record("get_push_config", params);
+            Err(A2AError::internal("stub"))
+        }
+
+        async fn list_push_configs(
+            &self,
+            params: &ServiceParams,
+            _req: ListTaskPushNotificationConfigsRequest,
+        ) -> Result<ListTaskPushNotificationConfigsResponse, A2AError> {
+            self.record("list_push_configs", params);
+            Ok(ListTaskPushNotificationConfigsResponse {
+                configs: Vec::new(),
+                next_page_token: None,
+            })
+        }
+
+        async fn delete_push_config(
+            &self,
+            params: &ServiceParams,
+            _req: DeleteTaskPushNotificationConfigRequest,
+        ) -> Result<(), A2AError> {
+            self.record("delete_push_config", params);
+            Ok(())
+        }
+
+        async fn get_extended_agent_card(
+            &self,
+            params: &ServiceParams,
+            _req: GetExtendedAgentCardRequest,
+        ) -> Result<AgentCard, A2AError> {
+            self.record("get_extended_agent_card", params);
+            Err(A2AError::internal("stub"))
+        }
+    }
+
+    /// Assert that `method` was called with a service-params entry matching `header = expected`.
+    #[track_caller]
+    pub(crate) fn assert_header_captured(
+        captured: &CapturedParams,
+        method: &'static str,
+        header: &str,
+        expected: &str,
+    ) {
+        let captured = captured.lock().unwrap();
+        let params = captured
+            .get(method)
+            .unwrap_or_else(|| panic!("{method} should have been called; captured={captured:?}"));
+        assert_eq!(
+            params.get(header),
+            Some(&vec![expected.to_string()]),
+            "{header} should be propagated to {method}; got {params:?}",
+        );
     }
 }

--- a/a2a-server/src/middleware.rs
+++ b/a2a-server/src/middleware.rs
@@ -2,11 +2,30 @@
 // SPDX-License-Identifier: Apache-2.0
 use a2a::A2AError;
 use async_trait::async_trait;
+use axum::http::HeaderMap;
 use serde_json::Value;
 use std::collections::HashMap;
 
 /// Service parameters — metadata from HTTP headers or gRPC metadata.
 pub type ServiceParams = HashMap<String, Vec<String>>;
+
+/// Build [`ServiceParams`] from an axum [`HeaderMap`].
+///
+/// Header names are normalized to lowercase (axum does this for us), values
+/// that aren't valid ASCII are silently skipped, and multi-valued headers
+/// produce a `Vec<String>` in insertion order.
+pub(crate) fn extract_service_params(headers: &HeaderMap) -> ServiceParams {
+    let mut params = ServiceParams::new();
+    for (name, value) in headers {
+        if let Ok(v) = value.to_str() {
+            params
+                .entry(name.as_str().to_owned())
+                .or_default()
+                .push(v.to_owned());
+        }
+    }
+    params
+}
 
 /// Authenticated user information.
 #[derive(Debug, Clone)]
@@ -109,6 +128,77 @@ impl CallInterceptor for LoggingInterceptor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::HeaderValue;
+
+    #[test]
+    fn test_extract_service_params_empty() {
+        let headers = HeaderMap::new();
+        let params = extract_service_params(&headers);
+        assert!(params.is_empty());
+    }
+
+    #[test]
+    fn test_extract_service_params_basic() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            HeaderValue::from_static("Bearer token-abc"),
+        );
+        headers.insert("x-tenant-id", HeaderValue::from_static("acme"));
+
+        let params = extract_service_params(&headers);
+
+        assert_eq!(
+            params.get("authorization"),
+            Some(&vec!["Bearer token-abc".to_string()])
+        );
+        assert_eq!(params.get("x-tenant-id"), Some(&vec!["acme".to_string()]));
+    }
+
+    #[test]
+    fn test_extract_service_params_multi_value() {
+        let mut headers = HeaderMap::new();
+        headers.append("x-forwarded-for", HeaderValue::from_static("10.0.0.1"));
+        headers.append("x-forwarded-for", HeaderValue::from_static("10.0.0.2"));
+
+        let params = extract_service_params(&headers);
+
+        assert_eq!(
+            params.get("x-forwarded-for"),
+            Some(&vec!["10.0.0.1".to_string(), "10.0.0.2".to_string()]),
+        );
+    }
+
+    #[test]
+    fn test_extract_service_params_lowercases_names() {
+        let mut headers = HeaderMap::new();
+        // HeaderMap normalizes the name to lowercase regardless of casing here.
+        headers.insert("Authorization", HeaderValue::from_static("Bearer cased"));
+        let params = extract_service_params(&headers);
+        assert_eq!(
+            params.get("authorization"),
+            Some(&vec!["Bearer cased".to_string()])
+        );
+        assert!(!params.contains_key("Authorization"));
+    }
+
+    #[test]
+    fn test_extract_service_params_skips_non_ascii_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-ascii", HeaderValue::from_static("ok"));
+        headers.insert(
+            "x-binary",
+            HeaderValue::from_bytes(&[0xff, 0xfe, 0xfd]).unwrap(),
+        );
+
+        let params = extract_service_params(&headers);
+
+        assert_eq!(params.get("x-ascii"), Some(&vec!["ok".to_string()]));
+        assert!(
+            !params.contains_key("x-binary"),
+            "non-ASCII value should be skipped, not produce an empty entry"
+        );
+    }
 
     #[test]
     fn test_user_authenticated() {

--- a/a2a-server/src/rest.rs
+++ b/a2a-server/src/rest.rs
@@ -7,7 +7,7 @@ use a2a_pb::protojson_conv::{self, ProtoJsonPayload};
 use axum::{
     Json,
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{HeaderMap, StatusCode},
     response::IntoResponse,
 };
 use chrono::{DateTime, Utc};
@@ -17,7 +17,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::handler::RequestHandler;
-use crate::middleware::ServiceParams;
+use crate::middleware::{ServiceParams, extract_service_params};
 use crate::sse;
 
 const REST_SEND_MESSAGE_PATH: &str = "/message:send";
@@ -120,13 +120,14 @@ pub fn rest_router<H: RequestHandler>(handler: Arc<H>) -> axum::Router {
 
 async fn handle_send_message<H: RequestHandler>(
     State(state): State<RestState<H>>,
+    headers: HeaderMap,
     Json(raw_req): Json<Value>,
 ) -> impl IntoResponse {
     let req = match protojson_conv::from_value::<SendMessageRequest>(raw_req) {
         Ok(req) => req,
         Err(e) => return rest_payload_error_response(e),
     };
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     match state.handler.send_message(&params, req).await {
         Ok(resp) => protojson_json_response(&resp),
         Err(e) => rest_error_response(e),
@@ -135,13 +136,14 @@ async fn handle_send_message<H: RequestHandler>(
 
 async fn handle_stream_message<H: RequestHandler>(
     State(state): State<RestState<H>>,
+    headers: HeaderMap,
     Json(raw_req): Json<Value>,
 ) -> impl IntoResponse {
     let req = match protojson_conv::from_value::<SendMessageRequest>(raw_req) {
         Ok(req) => req,
         Err(e) => return rest_payload_error_response(e),
     };
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     match state.handler.send_streaming_message(&params, req).await {
         Ok(stream) => sse::sse_from_stream(protojson_stream(stream)).into_response(),
         Err(e) => rest_error_response(e),
@@ -156,10 +158,10 @@ pub struct GetTaskQuery {
 
 async fn handle_get_task_inner<H: RequestHandler>(
     state: RestState<H>,
+    params: ServiceParams,
     id: String,
     query: GetTaskQuery,
 ) -> axum::response::Response {
-    let params = ServiceParams::new();
     let req = GetTaskRequest {
         id,
         history_length: query.history_length,
@@ -175,12 +177,14 @@ async fn handle_get_task_or_subscribe<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
     Query(query): Query<GetTaskQuery>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
+    let params = extract_service_params(&headers);
     if let Some(task_id) = id.strip_suffix(":subscribe") {
-        return handle_subscribe_to_task_inner(state, task_id.to_string()).await;
+        return handle_subscribe_to_task_inner(state, params, task_id.to_string()).await;
     }
 
-    handle_get_task_inner(state, id, query).await
+    handle_get_task_inner(state, params, id, query).await
 }
 
 #[derive(Deserialize)]
@@ -206,8 +210,9 @@ pub struct ListTasksQuery {
 async fn handle_list_tasks<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Query(query): Query<ListTasksQuery>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     let status = query
         .status
         .and_then(|s| serde_json::from_value::<TaskState>(serde_json::Value::String(s)).ok());
@@ -229,9 +234,9 @@ async fn handle_list_tasks<H: RequestHandler>(
 
 async fn handle_cancel_task_inner<H: RequestHandler>(
     state: RestState<H>,
+    params: ServiceParams,
     id: String,
 ) -> axum::response::Response {
-    let params = ServiceParams::new();
     let req = CancelTaskRequest {
         id,
         metadata: None,
@@ -246,12 +251,14 @@ async fn handle_cancel_task_inner<H: RequestHandler>(
 async fn handle_post_task_action<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
+    let params = extract_service_params(&headers);
     if let Some(task_id) = id.strip_suffix(":cancel") {
-        return handle_cancel_task_inner(state, task_id.to_string()).await;
+        return handle_cancel_task_inner(state, params, task_id.to_string()).await;
     }
     if let Some(task_id) = id.strip_suffix(":subscribe") {
-        return handle_subscribe_to_task_inner(state, task_id.to_string()).await;
+        return handle_subscribe_to_task_inner(state, params, task_id.to_string()).await;
     }
 
     rest_error_response(A2AError::invalid_request("unsupported task action"))
@@ -260,15 +267,17 @@ async fn handle_post_task_action<H: RequestHandler>(
 async fn handle_cancel_task_legacy<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
-    handle_cancel_task_inner(state, id).await
+    let params = extract_service_params(&headers);
+    handle_cancel_task_inner(state, params, id).await
 }
 
 async fn handle_subscribe_to_task_inner<H: RequestHandler>(
     state: RestState<H>,
+    params: ServiceParams,
     id: String,
 ) -> axum::response::Response {
-    let params = ServiceParams::new();
     let req = SubscribeToTaskRequest { id, tenant: None };
     match state.handler.subscribe_to_task(&params, req).await {
         Ok(stream) => sse::sse_from_stream(protojson_stream(stream)).into_response(),
@@ -279,8 +288,10 @@ async fn handle_subscribe_to_task_inner<H: RequestHandler>(
 async fn handle_subscribe_to_task_legacy<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
-    handle_subscribe_to_task_inner(state, id).await
+    let params = extract_service_params(&headers);
+    handle_subscribe_to_task_inner(state, params, id).await
 }
 
 #[derive(Deserialize)]
@@ -295,13 +306,14 @@ pub struct ListPushConfigsQuery {
 async fn handle_create_push_config<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
+    headers: HeaderMap,
     Json(raw_config): Json<Value>,
 ) -> impl IntoResponse {
     let req = match parse_create_push_config_request(id, raw_config) {
         Ok(req) => req,
         Err(e) => return rest_payload_error_response(e),
     };
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     match state.handler.create_push_config(&params, req).await {
         Ok(resp) => protojson_json_response(&resp),
         Err(e) => rest_error_response(e),
@@ -311,8 +323,9 @@ async fn handle_create_push_config<H: RequestHandler>(
 async fn handle_get_push_config<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path((id, config_id)): Path<(String, String)>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     let req = GetTaskPushNotificationConfigRequest {
         task_id: id,
         id: config_id,
@@ -328,8 +341,9 @@ async fn handle_list_push_configs<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path(id): Path<String>,
     Query(query): Query<ListPushConfigsQuery>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     let req = ListTaskPushNotificationConfigsRequest {
         task_id: id,
         page_size: query.page_size,
@@ -345,8 +359,9 @@ async fn handle_list_push_configs<H: RequestHandler>(
 async fn handle_delete_push_config<H: RequestHandler>(
     State(state): State<RestState<H>>,
     Path((id, config_id)): Path<(String, String)>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     let req = DeleteTaskPushNotificationConfigRequest {
         task_id: id,
         id: config_id,
@@ -360,8 +375,9 @@ async fn handle_delete_push_config<H: RequestHandler>(
 
 async fn handle_get_extended_agent_card<H: RequestHandler>(
     State(state): State<RestState<H>>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
-    let params = ServiceParams::new();
+    let params = extract_service_params(&headers);
     let req = GetExtendedAgentCardRequest { tenant: None };
     match state.handler.get_extended_agent_card(&params, req).await {
         Ok(card) => protojson_json_response(&card),
@@ -494,7 +510,7 @@ mod tests {
     use futures::stream::BoxStream;
     use http_body_util::BodyExt;
 
-    use crate::test_util::install_crypto_provider;
+    use crate::test_util::{CapturingHandler, assert_header_captured, install_crypto_provider};
     use tower::ServiceExt;
 
     struct EchoExecutor;
@@ -938,6 +954,289 @@ mod tests {
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_send_message_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+
+        let body = serde_json::json!({
+            "message": {
+                "messageId": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hi"}]
+            }
+        });
+        let req = Request::builder()
+            .uri(REST_SEND_MESSAGE_PATH)
+            .method("POST")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer test-token-abc")
+            .header("x-tenant-id", "acme")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+
+        assert_header_captured(
+            &captured,
+            "send_message",
+            "authorization",
+            "Bearer test-token-abc",
+        );
+        assert_header_captured(&captured, "send_message", "x-tenant-id", "acme");
+    }
+
+    #[tokio::test]
+    async fn test_stream_message_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+
+        let body = serde_json::json!({
+            "message": {
+                "messageId": "m1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hi"}]
+            }
+        });
+        let req = Request::builder()
+            .uri(REST_STREAM_MESSAGE_PATH)
+            .method("POST")
+            .header("content-type", "application/json")
+            .header("accept", "text/event-stream")
+            .header("authorization", "Bearer streaming-token")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        // Drain the SSE body to ensure the handler has been fully driven.
+        let _ = resp.into_body().collect().await.unwrap().to_bytes();
+
+        assert_header_captured(
+            &captured,
+            "send_streaming_message",
+            "authorization",
+            "Bearer streaming-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_task_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/some-id")
+            .method("GET")
+            .header("authorization", "Bearer get-task-token")
+            .header("x-tenant-id", "acme")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "get_task",
+            "authorization",
+            "Bearer get-task-token",
+        );
+        assert_header_captured(&captured, "get_task", "x-tenant-id", "acme");
+    }
+
+    #[tokio::test]
+    async fn test_list_tasks_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks")
+            .method("GET")
+            .header("authorization", "Bearer list-tasks-token")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "list_tasks",
+            "authorization",
+            "Bearer list-tasks-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cancel_task_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/some-id:cancel")
+            .method("POST")
+            .header("authorization", "Bearer cancel-token")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "cancel_task",
+            "authorization",
+            "Bearer cancel-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cancel_task_legacy_propagates_headers_as_service_params() {
+        // /tasks/{id}/cancel routes through handle_cancel_task_legacy.
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/some-id/cancel")
+            .method("POST")
+            .header("authorization", "Bearer cancel-legacy-token")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "cancel_task",
+            "authorization",
+            "Bearer cancel-legacy-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_push_config_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let body = serde_json::json!({
+            "id": "cfg1",
+            "url": "http://example.com/callback"
+        });
+        let req = Request::builder()
+            .uri("/tasks/t1/pushNotificationConfigs")
+            .method("POST")
+            .header("content-type", "application/json")
+            .header("authorization", "Bearer push-create-token")
+            .body(Body::from(serde_json::to_string(&body).unwrap()))
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "create_push_config",
+            "authorization",
+            "Bearer push-create-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_push_configs_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/t1/pushNotificationConfigs")
+            .method("GET")
+            .header("authorization", "Bearer push-list-token")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "list_push_configs",
+            "authorization",
+            "Bearer push-list-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_push_config_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/t1/pushNotificationConfigs/cfg1")
+            .method("GET")
+            .header("authorization", "Bearer push-get-token")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "get_push_config",
+            "authorization",
+            "Bearer push-get-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_delete_push_config_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/t1/pushNotificationConfigs/cfg1")
+            .method("DELETE")
+            .header("authorization", "Bearer push-delete-token")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "delete_push_config",
+            "authorization",
+            "Bearer push-delete-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_extended_agent_card_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri(REST_EXTENDED_AGENT_CARD_PATH)
+            .method("GET")
+            .header("authorization", "Bearer card-token")
+            .body(Body::empty())
+            .unwrap();
+        let _ = app.oneshot(req).await.unwrap();
+        assert_header_captured(
+            &captured,
+            "get_extended_agent_card",
+            "authorization",
+            "Bearer card-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_to_task_propagates_headers_as_service_params() {
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/some-id:subscribe")
+            .method("GET")
+            .header("authorization", "Bearer subscribe-token")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let _ = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_header_captured(
+            &captured,
+            "subscribe_to_task",
+            "authorization",
+            "Bearer subscribe-token",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_to_task_legacy_propagates_headers_as_service_params() {
+        // /tasks/{id}/subscribe routes through handle_subscribe_to_task_legacy.
+        let (handler, captured) = CapturingHandler::new();
+        let app = rest_router(handler);
+        let req = Request::builder()
+            .uri("/tasks/some-id/subscribe")
+            .method("GET")
+            .header("authorization", "Bearer subscribe-legacy-token")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let _ = resp.into_body().collect().await.unwrap().to_bytes();
+        assert_header_captured(
+            &captured,
+            "subscribe_to_task",
+            "authorization",
+            "Bearer subscribe-legacy-token",
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The axum-based HTTP (`rest`) and JSON-RPC transports in `a2a-server` constructed an empty `ServiceParams` at every entry point, so downstream `AgentExecutor` and `RequestHandler` implementations always saw `ctx.service_params` as `{}` regardless of what headers the client sent. This broke any executor or handler logic that depends on transport metadata — forwarding an incoming `Authorization` header to a downstream service, tenant routing, request-correlation IDs, etc.

The gRPC and slimrpc transports in this workspace already populate `ServiceParams` from their transport metadata (`a2a-grpc/src/server.rs:34`, `a2a-slimrpc/src/common.rs:70`). This change brings the HTTP transports to parity.

This should resolve issue #69 

## Changes

- **`a2a-server/src/rest.rs`** — added `extract_service_params(&HeaderMap) -> ServiceParams` and wired a `HeaderMap` extractor through every axum handler (`handle_send_message`, `handle_stream_message`, `handle_get_task_or_subscribe`, `handle_list_tasks`, `handle_post_task_action`, `handle_cancel_task_legacy`, `handle_subscribe_to_task_legacy`, `handle_create_push_config`, `handle_get_push_config`, `handle_list_push_configs`, `handle_delete_push_config`, `handle_get_extended_agent_card`). The private `_inner` helpers now take a `ServiceParams` argument from their callers.
- **`a2a-server/src/jsonrpc.rs`** — added the same helper and wired a `HeaderMap` extractor through `handle_jsonrpc`.

No public API signatures changed. `rest_router`, `jsonrpc_router`, `RestState`, `JsonRpcState`, and the `RequestHandler` trait are all untouched.

## Behavioral note: incoming request headers now reach executors

This change **exposes incoming HTTP request headers to executor / handler code** via `ctx.service_params`. This includes potentially sensitive headers like `Authorization`, `Cookie`, and `X-Api-Key`.

This is **the same exposure model the gRPC and slimrpc transports already provide** — both surface inbound transport metadata (gRPC metadata / slim context metadata) into the same `ServiceParams` map. The HTTP transports were the outlier, and the doc comment on `ServiceParams` always advertised this contract:

```rust
// a2a-server/src/middleware.rs
/// Service parameters — metadata from HTTP headers or gRPC metadata.
pub type ServiceParams = HashMap<String, Vec<String>>;
```

Conventions to be aware of:

- **Header names are lowercased** (axum normalizes them, matching HTTP/2 semantics). Look up headers as `params.get("authorization")`, not `"Authorization"`.
- **Multi-valued headers** produce `Vec<String>` entries in insertion order.
- **Non-ASCII / opaque-binary header values** are silently skipped, mirroring gRPC's handling of binary metadata entries.
- **No header filtering.** Hop-by-hop and framing headers (`host`, `content-length`, `accept`, `user-agent`, etc.) flow through verbatim. This matches gRPC, which also does not filter pseudo-headers.

**Operator guidance:** if your executor or `CallInterceptor` logs `ctx.service_params` wholesale (e.g. for debugging), audit those log statements before deploying this version — auth tokens and other secrets will now appear in those logs. The same caveat already applies to deployments using the gRPC or slimrpc transports.

## Test plan

A failing test for each transport was added first to reproduce the bug, then the fix was applied. Coverage spans every endpoint, not just the executor-driven ones:

### REST (`a2a-server/src/rest.rs`)

Executor-driven endpoints (via `CapturingExecutor` recording `ctx.service_params`):
- [x] `test_send_message_propagates_headers_as_service_params`
- [x] `test_stream_message_propagates_headers_as_service_params`

Non-executor endpoints (via a new `CapturingHandler` stub recording `ServiceParams` per `RequestHandler` method):
- [x] `test_get_task_propagates_headers_as_service_params`
- [x] `test_list_tasks_propagates_headers_as_service_params`
- [x] `test_cancel_task_propagates_headers_as_service_params`
- [x] `test_subscribe_to_task_propagates_headers_as_service_params`
- [x] `test_create_push_config_propagates_headers_as_service_params`
- [x] `test_get_push_config_propagates_headers_as_service_params`
- [x] `test_list_push_configs_propagates_headers_as_service_params`
- [x] `test_delete_push_config_propagates_headers_as_service_params`
- [x] `test_get_extended_agent_card_propagates_headers_as_service_params`

### JSON-RPC (`a2a-server/src/jsonrpc.rs`)

- [x] `test_send_message_propagates_headers_as_service_params` (unary)
- [x] `test_streaming_send_message_propagates_headers_as_service_params` (SSE)

### Verification

- [x] All 117 unit tests in `a2a-server` pass (the 13 propagation tests above + 104 pre-existing).
- [x] `cargo test --workspace` green.
- [x] `cargo clippy -p a2a-server-lf --all-targets` clean.

## Out of scope

- `ctx.user` remains hardcoded to `None` in `DefaultRequestHandler`. Surfacing an authenticated user from an interceptor hook is a separate, larger design choice and is intentionally deferred from this fix.
- No header deny-list / filtering layer is added; behavior matches the gRPC transport's pass-through model. Operators who want to redact specific headers can do so via a `CallInterceptor` or an axum middleware layer.
