### PR TITLE
feat(itk): add nightly ITK interoperability tests

### DIFF
--- a/.github/workflows/itk-nightly.yaml
+++ b/.github/workflows/itk-nightly.yaml
@@ -1,0 +1,39 @@
+name: Nightly ITK
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # 2:00 AM UTC daily, 2 hours before dashboard redeploy
+  workflow_dispatch:     # Allow manual trigger
+
+permissions:
+  contents: write
+
+concurrency:
+  group: itk-nightly
+  cancel-in-progress: true
+
+jobs:
+  nightly:
+    name: Nightly ITK Run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Run Nightly ITK Tests
+        run: bash run_itk.sh
+        working-directory: itk
+        env:
+          A2A_ITK_REVISION: main
+          ITK_NIGHTLY_RUN: "True"
+
+      - name: Upload Results to Rolling Release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+        with:
+          tag_name: "nightly-metrics"
+          prerelease: true
+          files: |
+            itk/itk_rust.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 /target/
 /coverage/
 examples/.certs/
+itk/target/
+itk/a2a-itk/
+itk/raw_results.json
+itk/itk_rust.json
+itk/logs/

--- a/itk/Cargo.toml
+++ b/itk/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "itk-rust-current-agent"
+version = "0.1.0"
+edition = "2024"
+publish = false
+rust-version = "1.85.0"
+
+[[bin]]
+name = "itk-rust-current-agent"
+path = "a2a-itk/agents/rust/v10/src/main.rs"
+
+[dependencies]
+a2a        = { package = "a2a-lf",        path = "../a2a" }
+a2a-server = { package = "a2a-server-lf", path = "../a2a-server", default-features = false }
+a2a-client = { package = "a2a-client-lf", path = "../a2a-client", default-features = false }
+a2a-grpc   = { package = "a2a-grpc",      path = "../a2a-grpc",   default-features = false }
+a2a-pb     = { package = "a2a-pb",        path = "../a2a-pb" }
+
+async-trait        = "0.1"
+async-stream       = "0.3"
+axum               = "0.8"
+base64             = "0.22"
+futures            = "0.3"
+prost              = "0.14"
+serde_json         = "1"
+tokio              = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
+tokio-stream       = { version = "0.1", features = ["net"] }
+tonic              = "0.14"
+tower-http         = { version = "0.6", features = ["normalize-path"] }
+tracing            = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[build-dependencies]
+prost-build = "0.14"

--- a/itk/build.rs
+++ b/itk/build.rs
@@ -1,0 +1,16 @@
+// Copyright AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // Prefer the local a2a-itk clone (created by run_itk.sh);
+    // fall back to the path baked into the ITK Docker image at build time.
+    let proto_dir = if std::path::Path::new("a2a-itk/protos").exists() {
+        "a2a-itk/protos"
+    } else {
+        "/tmp/protos"
+    };
+    let proto_file = format!("{proto_dir}/instruction.proto");
+    prost_build::compile_protos(&[proto_file.as_str()], &[proto_dir])
+        .expect("failed to compile instruction.proto");
+    println!("cargo:rerun-if-changed={proto_dir}/instruction.proto");
+}

--- a/itk/process_results.py
+++ b/itk/process_results.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+"""
+ITK results post-processor for a2a-rs nightly and CI runs.
+
+Usage
+-----
+CI mode  — reads raw JSON from stdin, prints per-test status, exits 1 on failure:
+    echo "$RESPONSE" | python3 process_results.py ci
+
+Nightly mode — reads raw_results.json, fetches rolling history, appends a new
+run entry and writes the updated history to the output file:
+    python3 process_results.py nightly \\
+        --scenarios  scenarios_full.json \\
+        --output     itk_rust.json \\
+        --history-url https://github.com/a2aproject/a2a-rs/releases/download/nightly-metrics/itk_rust.json
+"""
+
+import argparse
+import datetime
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+RAW_RESULTS_FILE = "raw_results.json"
+HISTORY_LIMIT = 50
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _passed(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, dict):
+        return bool(value.get("passed", False))
+    return False
+
+
+# ---------------------------------------------------------------------------
+# CI mode
+# ---------------------------------------------------------------------------
+
+def cmd_ci(args) -> int:
+    try:
+        data = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: could not parse response JSON: {exc}", file=sys.stderr)
+        return 1
+
+    results = data.get("results", {})
+    all_passed = data.get("all_passed", False)
+
+    print("-" * 56)
+    print("ITK TEST RESULTS:")
+    print("-" * 56)
+    for name, value in results.items():
+        status = "PASSED" if _passed(value) else "FAILED"
+        print(f"{name}: {status}")
+    print("-" * 56)
+    print(f"OVERALL STATUS: {'PASSED' if all_passed else 'FAILED'}")
+
+    return 0 if all_passed else 1
+
+
+# ---------------------------------------------------------------------------
+# Nightly mode
+# ---------------------------------------------------------------------------
+
+def _fetch_history(url: str) -> list:
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "a2a-rs/itk"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return []
+        raise
+    except Exception as exc:  # noqa: BLE001
+        print(f"WARNING: could not fetch history ({exc}); starting fresh", file=sys.stderr)
+        return []
+
+
+def _load_json(path: str) -> dict | list:
+    with open(path) as fh:
+        return json.load(fh)
+
+
+def _compile_scenarios(raw_results: dict, base_tests: list) -> list:
+    index = {t["name"]: t for t in base_tests}
+    compiled = []
+    for name, value in raw_results.items():
+        parent = name.split("-sub-")[0]
+        base = index.get(parent)
+        if base is None:
+            print(f"WARNING: no base scenario for result key '{name}'; skipping", file=sys.stderr)
+            continue
+
+        is_dict = isinstance(value, dict)
+        record = {
+            "name": name,
+            "sdks": value.get("sdks", base["sdks"]) if is_dict else base["sdks"],
+            "edges": value.get("edges", base.get("edges")) if is_dict else base.get("edges"),
+            "protocols": base.get("protocols"),
+            "behavior": base.get("behavior"),
+            "traversal": base.get("traversal", "euler"),
+            "passed": _passed(value),
+        }
+        for opt in ("streaming", "build_subtests"):
+            if opt in base:
+                record[opt] = base[opt]
+        compiled.append(record)
+    return compiled
+
+
+def cmd_nightly(args) -> int:
+    raw = _load_json(RAW_RESULTS_FILE)
+    scenarios_doc = _load_json(args.scenarios)
+    history = _fetch_history(args.history_url)
+
+    compiled = _compile_scenarios(raw.get("results", {}), scenarios_doc["tests"])
+
+    new_run = {
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "commit_sha": os.environ.get("GITHUB_SHA", "local-dev"),
+        "github_run_id": os.environ.get("GITHUB_RUN_ID", "0"),
+        "all_passed": raw.get("all_passed", False),
+        "scenarios": compiled,
+    }
+
+    history.append(new_run)
+    if len(history) > HISTORY_LIMIT:
+        history = history[-HISTORY_LIMIT:]
+
+    with open(args.output, "w") as fh:
+        json.dump(history, fh, indent=2)
+
+    print(f"Written {len(history)} history entries to {args.output}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("ci", help="Print CI test results (reads JSON from stdin)")
+
+    nightly = sub.add_parser("nightly", help="Build and persist nightly history")
+    nightly.add_argument("--scenarios",   required=True, help="Path to scenarios JSON file")
+    nightly.add_argument("--output",      required=True, help="Output history JSON file")
+    nightly.add_argument("--history-url", required=True, dest="history_url",
+                         help="URL of the existing rolling history release asset")
+
+    args = parser.parse_args()
+    return cmd_ci(args) if args.command == "ci" else cmd_nightly(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+set -ex
+
+export ITK_LOG_LEVEL="${ITK_LOG_LEVEL:-INFO}"
+RESULT=1
+
+cleanup() {
+  set +x
+  echo "Cleaning up artifacts..."
+  docker stop itk-service > /dev/null 2>&1 || true
+  docker rm itk-service > /dev/null 2>&1 || true
+  docker rmi itk_service > /dev/null 2>&1 || true
+  rm -rf a2a-itk > /dev/null 2>&1 || true
+  echo "Done. Final exit code: $RESULT"
+}
+trap cleanup EXIT
+
+: "${A2A_ITK_REVISION:?A2A_ITK_REVISION environment variable must be set}"
+
+if [ ! -d "a2a-itk" ]; then
+  git clone https://github.com/a2aproject/a2a-itk.git a2a-itk
+fi
+cd a2a-itk
+git fetch origin
+git checkout "$A2A_ITK_REVISION"
+if git symbolic-ref -q HEAD > /dev/null; then
+  git pull origin "$A2A_ITK_REVISION"
+fi
+cd ..
+
+# Build the ITK service Docker image (polyglot: includes Rust 1.85, Go, Python, Node, etc.)
+docker build -t itk_service a2a-itk
+
+A2A_RS_ROOT=$(cd .. && pwd)
+ITK_DIR=$(pwd)
+
+docker rm -f itk-service || true
+
+DOCKER_MOUNT_LOGS=""
+if [ "${ITK_LOG_LEVEL^^}" = "DEBUG" ]; then
+  mkdir -p "$ITK_DIR/logs"
+  DOCKER_MOUNT_LOGS="-v $ITK_DIR/logs:/app/logs"
+fi
+
+docker run -d --name itk-service \
+  -v "$A2A_RS_ROOT:/app/agents/repo" \
+  -v "$ITK_DIR:/app/agents/repo/itk" \
+  $DOCKER_MOUNT_LOGS \
+  -e ITK_LOG_LEVEL="$ITK_LOG_LEVEL" \
+  -p 8000:8000 \
+  itk_service
+
+docker exec -u root itk-service git config --system --add safe.directory /app/agents/repo
+docker exec -u root itk-service git config --system --add safe.directory /app/agents/repo/itk
+docker exec -u root itk-service git config --system core.multiPackIndex false
+
+MAX_RETRIES=30
+echo "Waiting for ITK service to start on 127.0.0.1:8000..."
+set +e
+for i in $(seq 1 $MAX_RETRIES); do
+  if curl -s http://127.0.0.1:8000/ > /dev/null; then
+    echo "Service is up!"
+    break
+  fi
+  echo "Still waiting... ($i/$MAX_RETRIES)"
+  sleep 2
+done
+
+if ! curl -s http://127.0.0.1:8000/ > /dev/null; then
+  echo "Error: ITK service failed to start on port 8000"
+  docker logs itk-service
+  exit 1
+fi
+
+SCENARIO_FILE="scenarios.json"
+if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
+  SCENARIO_FILE="scenarios_full.json"
+fi
+
+echo "ITK Service is up! Sending compatibility test request using $SCENARIO_FILE..."
+RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
+  -H "Content-Type: application/json" \
+  -d "@$SCENARIO_FILE")
+
+if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
+  echo "Nightly run detected. Saving raw results and running process_results.py..."
+  echo "$RESPONSE" > raw_results.json
+  python3 a2a-itk/scripts/process_results.py \
+    --history_output_file itk_rust.json \
+    --history_url https://github.com/a2aproject/a2a-rs/releases/download/nightly-metrics/itk_rust.json
+  RESULT=$?
+else
+  echo "--------------------------------------------------------"
+  echo "ITK TEST RESULTS:"
+  echo "--------------------------------------------------------"
+  echo "$RESPONSE" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    all_passed = data.get('all_passed', False)
+    results = data.get('results', {})
+    for test, passed in results.items():
+        status = 'PASSED' if passed else 'FAILED'
+        print(f'{test}: {status}')
+    print('--------------------------------------------------------')
+    print(f'OVERALL STATUS: {\"PASSED\" if all_passed else \"FAILED\"}')
+    if not all_passed:
+        sys.exit(1)
+except Exception as e:
+    print(f'Error parsing results: {e}')
+    sys.exit(1)
+"
+  RESULT=$?
+fi
+set -e
+
+if [ $RESULT -ne 0 ]; then
+  echo "Tests failed. Container logs:"
+  docker logs itk-service
+fi
+echo "--------------------------------------------------------"
+
+exit $RESULT

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -5,7 +5,7 @@ set -ex
 
 # Always run from the directory containing this script so relative paths work
 # regardless of where the caller invokes it from.
-cd "$(dirname "$0")"
+cd "$(dirname "${BASH_SOURCE[0]}")"
 
 export ITK_LOG_LEVEL="${ITK_LOG_LEVEL:-INFO}"
 RESULT=1

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -95,81 +95,14 @@ RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
 if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
   echo "Nightly run detected. Saving raw results and processing history..."
   echo "$RESPONSE" > raw_results.json
-
-  # Fetch existing rolling history; start fresh if the release asset doesn't exist yet.
-  HISTORY_URL="https://github.com/a2aproject/a2a-rs/releases/download/nightly-metrics/itk_rust.json"
-  HISTORY=$(curl -sSLf "$HISTORY_URL" 2>/dev/null || echo "[]")
-
-  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
-
-  # Build the new run entry, append it to the rolling history, and prune to 50 entries.
-  # Mirrors the logic in a2a-itk/scripts/process_results.py using jq only.
-  jq -n \
-    --arg ts        "$TIMESTAMP" \
-    --arg sha       "${GITHUB_SHA:-local-dev}" \
-    --arg run_id    "${GITHUB_RUN_ID:-0}" \
-    --slurpfile raw       raw_results.json \
-    --slurpfile scenarios "$SCENARIO_FILE" \
-    --argjson history     "$HISTORY" \
-    '
-    ($raw[0])            as $data       |
-    ($scenarios[0].tests) as $base_tests |
-    ($data.results // {}) as $results   |
-
-    # Compile per-scenario records, skipping any result key with no matching base.
-    [$results | to_entries[] |
-      . as $entry |
-      ($entry.key | split("-sub-")[0]) as $parent |
-      ([$base_tests[] | select(.name == $parent)][0]) as $base |
-      if $base == null then empty else
-        (($entry.value | type) == "boolean") as $is_bool |
-        (if $is_bool then $entry.value          else ($entry.value.passed // false) end) as $passed |
-        (if $is_bool then $base.sdks            else ($entry.value.sdks   // $base.sdks)  end) as $sdks  |
-        (if $is_bool then $base.edges           else ($entry.value.edges  // $base.edges) end) as $edges |
-        {
-          name:      $entry.key,
-          sdks:      $sdks,
-          edges:     $edges,
-          protocols: $base.protocols,
-          behavior:  $base.behavior,
-          traversal: ($base.traversal // "euler"),
-          passed:    $passed
-        }
-        + (if $base | has("streaming")     then {streaming:     $base.streaming}     else {} end)
-        + (if $base | has("build_subtests") then {build_subtests: $base.build_subtests} else {} end)
-      end
-    ] as $compiled |
-
-    ($history + [{
-      timestamp:     $ts,
-      commit_sha:    $sha,
-      github_run_id: $run_id,
-      all_passed:    ($data.all_passed // false),
-      scenarios:     $compiled
-    }])[-50:]
-    ' > itk_rust.json
+  python3 process_results.py nightly \
+    --scenarios  "$SCENARIO_FILE" \
+    --output     itk_rust.json \
+    --history-url https://github.com/a2aproject/a2a-rs/releases/download/nightly-metrics/itk_rust.json
   RESULT=$?
 else
-  echo "--------------------------------------------------------"
-  echo "ITK TEST RESULTS:"
-  echo "--------------------------------------------------------"
-  echo "$RESPONSE" | jq -r '
-    .results | to_entries[] |
-    .key + ": " + (
-      if   (.value | type) == "boolean" then (if .value          then "PASSED" else "FAILED" end)
-      else                                   (if .value.passed // false then "PASSED" else "FAILED" end)
-      end
-    )
-  '
-  ALL_PASSED=$(echo "$RESPONSE" | jq -r '.all_passed // false')
-  echo "--------------------------------------------------------"
-  if [ "$ALL_PASSED" = "true" ]; then
-    echo "OVERALL STATUS: PASSED"
-    RESULT=0
-  else
-    echo "OVERALL STATUS: FAILED"
-    RESULT=1
-  fi
+  echo "$RESPONSE" | python3 process_results.py ci
+  RESULT=$?
 fi
 set -e
 

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -16,7 +16,7 @@ cleanup() {
   docker stop itk-service > /dev/null 2>&1 || true
   docker rm itk-service > /dev/null 2>&1 || true
   # Preserve the image so layer caching speeds up subsequent local runs.
-  # Re-export ITK_REMOVE_IMAGE=1 to force removal (e.g. in CI cleanup jobs).
+  # Set ITK_REMOVE_IMAGE=1 to force removal (e.g. in CI cleanup jobs).
   if [ "${ITK_REMOVE_IMAGE:-0}" = "1" ]; then
     docker rmi itk_service > /dev/null 2>&1 || true
   fi
@@ -93,34 +93,83 @@ RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
   -d "@$SCENARIO_FILE")
 
 if [ "${ITK_NIGHTLY_RUN^^}" = "TRUE" ]; then
-  echo "Nightly run detected. Saving raw results and running process_results.py..."
+  echo "Nightly run detected. Saving raw results and processing history..."
   echo "$RESPONSE" > raw_results.json
-  python3 a2a-itk/scripts/process_results.py \
-    --history_output_file itk_rust.json \
-    --history_url https://github.com/a2aproject/a2a-rs/releases/download/nightly-metrics/itk_rust.json
+
+  # Fetch existing rolling history; start fresh if the release asset doesn't exist yet.
+  HISTORY_URL="https://github.com/a2aproject/a2a-rs/releases/download/nightly-metrics/itk_rust.json"
+  HISTORY=$(curl -sSLf "$HISTORY_URL" 2>/dev/null || echo "[]")
+
+  TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%S+00:00")
+
+  # Build the new run entry, append it to the rolling history, and prune to 50 entries.
+  # Mirrors the logic in a2a-itk/scripts/process_results.py using jq only.
+  jq -n \
+    --arg ts        "$TIMESTAMP" \
+    --arg sha       "${GITHUB_SHA:-local-dev}" \
+    --arg run_id    "${GITHUB_RUN_ID:-0}" \
+    --slurpfile raw       raw_results.json \
+    --slurpfile scenarios "$SCENARIO_FILE" \
+    --argjson history     "$HISTORY" \
+    '
+    ($raw[0])            as $data       |
+    ($scenarios[0].tests) as $base_tests |
+    ($data.results // {}) as $results   |
+
+    # Compile per-scenario records, skipping any result key with no matching base.
+    [$results | to_entries[] |
+      . as $entry |
+      ($entry.key | split("-sub-")[0]) as $parent |
+      ([$base_tests[] | select(.name == $parent)][0]) as $base |
+      if $base == null then empty else
+        (($entry.value | type) == "boolean") as $is_bool |
+        (if $is_bool then $entry.value          else ($entry.value.passed // false) end) as $passed |
+        (if $is_bool then $base.sdks            else ($entry.value.sdks   // $base.sdks)  end) as $sdks  |
+        (if $is_bool then $base.edges           else ($entry.value.edges  // $base.edges) end) as $edges |
+        {
+          name:      $entry.key,
+          sdks:      $sdks,
+          edges:     $edges,
+          protocols: $base.protocols,
+          behavior:  $base.behavior,
+          traversal: ($base.traversal // "euler"),
+          passed:    $passed
+        }
+        + (if $base | has("streaming")     then {streaming:     $base.streaming}     else {} end)
+        + (if $base | has("build_subtests") then {build_subtests: $base.build_subtests} else {} end)
+      end
+    ] as $compiled |
+
+    ($history + [{
+      timestamp:     $ts,
+      commit_sha:    $sha,
+      github_run_id: $run_id,
+      all_passed:    ($data.all_passed // false),
+      scenarios:     $compiled
+    }])[-50:]
+    ' > itk_rust.json
   RESULT=$?
 else
   echo "--------------------------------------------------------"
   echo "ITK TEST RESULTS:"
   echo "--------------------------------------------------------"
-  echo "$RESPONSE" | python3 -c "
-import sys, json
-try:
-    data = json.load(sys.stdin)
-    all_passed = data.get('all_passed', False)
-    results = data.get('results', {})
-    for test, passed in results.items():
-        status = 'PASSED' if passed else 'FAILED'
-        print(f'{test}: {status}')
-    print('--------------------------------------------------------')
-    print(f'OVERALL STATUS: {\"PASSED\" if all_passed else \"FAILED\"}')
-    if not all_passed:
-        sys.exit(1)
-except Exception as e:
-    print(f'Error parsing results: {e}')
-    sys.exit(1)
-"
-  RESULT=$?
+  echo "$RESPONSE" | jq -r '
+    .results | to_entries[] |
+    .key + ": " + (
+      if   (.value | type) == "boolean" then (if .value          then "PASSED" else "FAILED" end)
+      else                                   (if .value.passed // false then "PASSED" else "FAILED" end)
+      end
+    )
+  '
+  ALL_PASSED=$(echo "$RESPONSE" | jq -r '.all_passed // false')
+  echo "--------------------------------------------------------"
+  if [ "$ALL_PASSED" = "true" ]; then
+    echo "OVERALL STATUS: PASSED"
+    RESULT=0
+  else
+    echo "OVERALL STATUS: FAILED"
+    RESULT=1
+  fi
 fi
 set -e
 

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 set -ex
 
+# Always run from the directory containing this script so relative paths work
+# regardless of where the caller invokes it from.
+cd "$(dirname "$0")"
+
 export ITK_LOG_LEVEL="${ITK_LOG_LEVEL:-INFO}"
 RESULT=1
 
@@ -11,7 +15,11 @@ cleanup() {
   echo "Cleaning up artifacts..."
   docker stop itk-service > /dev/null 2>&1 || true
   docker rm itk-service > /dev/null 2>&1 || true
-  docker rmi itk_service > /dev/null 2>&1 || true
+  # Preserve the image so layer caching speeds up subsequent local runs.
+  # Re-export ITK_REMOVE_IMAGE=1 to force removal (e.g. in CI cleanup jobs).
+  if [ "${ITK_REMOVE_IMAGE:-0}" = "1" ]; then
+    docker rmi itk_service > /dev/null 2>&1 || true
+  fi
   rm -rf a2a-itk > /dev/null 2>&1 || true
   echo "Done. Final exit code: $RESULT"
 }

--- a/itk/scenarios.json
+++ b/itk/scenarios.json
@@ -1,0 +1,20 @@
+{
+  "tests": [
+    {
+      "name": "CI - JSONRPC - Send Message",
+      "sdks": ["current", "go_v10"],
+      "edges": ["0->1", "1->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "CI - GRPC - Send Message",
+      "sdks": ["current", "go_v10"],
+      "edges": ["0->1", "1->0"],
+      "protocols": ["grpc"],
+      "behavior": "send_message",
+      "build_subtests": true
+    }
+  ]
+}

--- a/itk/scenarios_full.json
+++ b/itk/scenarios_full.json
@@ -1,0 +1,106 @@
+{
+  "tests": [
+    {
+      "name": "Nightly - JSONRPC - Send Message",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - JSONRPC - Send Message (Streaming)",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - JSONRPC - Push Notification",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "behavior": "push_notification",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - JSONRPC - Resubscribe",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["jsonrpc"],
+      "streaming": true,
+      "behavior": "resubscribe",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Send Message",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Send Message (Streaming)",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "streaming": true,
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Push Notification",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "behavior": "push_notification",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - GRPC - Resubscribe",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["grpc"],
+      "streaming": true,
+      "behavior": "resubscribe",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Send Message",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Send Message (Streaming)",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "streaming": true,
+      "behavior": "send_message",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Push Notification",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "behavior": "push_notification",
+      "build_subtests": true
+    },
+    {
+      "name": "Nightly - HTTP_JSON - Resubscribe",
+      "sdks": ["current", "rust_v10", "go_v10", "python_v10", "java_v10"],
+      "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+      "protocols": ["http_json"],
+      "streaming": true,
+      "behavior": "resubscribe",
+      "build_subtests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `itk/` with a standalone Rust agent (`itk-rust-current-agent`) that serves JSON-RPC, REST, and gRPC using the local in-tree SDK crates
- Adds `itk/scenarios_full.json` with 12 nightly tests (3 protocols × 4 behaviors) against `rust_v10`, `go_v10`, `python_v10`, and `java_v10`
- Adds `.github/workflows/itk-nightly.yaml` running at 02:00 UTC, uploading results to the `nightly-metrics` release tag consumed by the [a2a-itk dashboard](https://a2aproject.github.io/a2a-itk/dashboard) at 04:00 UTC

## Test plan

- [ ] Trigger the `Nightly ITK` workflow manually via `workflow_dispatch`
- [ ] Verify `itk_rust.json` appears under the `nightly-metrics` pre-release tag
- [ ] Confirm results show up on the a2a-itk dashboard after its 04:00 UTC redeploy