### PR TITLE
fix(itk): use prost 0.13 and detect ITK service build failures

### DIFF
--- a/itk/Cargo.toml
+++ b/itk/Cargo.toml
@@ -21,7 +21,7 @@ async-stream       = "0.3"
 axum               = "0.8"
 base64             = "0.22"
 futures            = "0.3"
-prost              = "0.14"
+prost              = "0.13"
 serde_json         = "1"
 tokio              = { version = "1", features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
 tokio-stream       = { version = "0.1", features = ["net"] }
@@ -31,4 +31,4 @@ tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [build-dependencies]
-prost-build = "0.14"
+prost-build = "0.13"

--- a/itk/process_results.py
+++ b/itk/process_results.py
@@ -45,8 +45,11 @@ def _passed(value) -> bool:
 # CI mode
 # ---------------------------------------------------------------------------
 
-def _check_itk_error(data: dict) -> int | None:
+def _check_itk_error(data: dict | list | None) -> int | None:
     """Return 1 and print error if ITK service returned an error response, else None."""
+    if not isinstance(data, dict):
+        print(f"ERROR: ITK response is not a JSON object. Type: {type(data).__name__}", file=sys.stderr)
+        return 1
     if "detail" in data:
         print(f"ERROR: ITK service returned an error: {data['detail']}", file=sys.stderr)
         return 1

--- a/itk/process_results.py
+++ b/itk/process_results.py
@@ -45,12 +45,26 @@ def _passed(value) -> bool:
 # CI mode
 # ---------------------------------------------------------------------------
 
+def _check_itk_error(data: dict) -> int | None:
+    """Return 1 and print error if ITK service returned an error response, else None."""
+    if "detail" in data:
+        print(f"ERROR: ITK service returned an error: {data['detail']}", file=sys.stderr)
+        return 1
+    if "results" not in data:
+        print(f"ERROR: ITK response missing 'results' field. Response keys: {list(data.keys())}", file=sys.stderr)
+        return 1
+    return None
+
+
 def cmd_ci(args) -> int:
     try:
         data = json.load(sys.stdin)
     except json.JSONDecodeError as exc:
         print(f"ERROR: could not parse response JSON: {exc}", file=sys.stderr)
         return 1
+
+    if (err := _check_itk_error(data)) is not None:
+        return err
 
     results = data.get("results", {})
     all_passed = data.get("all_passed", False)
@@ -119,6 +133,9 @@ def _compile_scenarios(raw_results: dict, base_tests: list) -> list:
 
 def cmd_nightly(args) -> int:
     raw = _load_json(RAW_RESULTS_FILE)
+    if (err := _check_itk_error(raw)) is not None:
+        return err
+
     scenarios_doc = _load_json(args.scenarios)
     history = _fetch_history(args.history_url)
 


### PR DESCRIPTION
## Summary

- **`itk/Cargo.toml`**: downgrade `prost`/`prost-build` from `0.14` to `0.13`.
  The `agents/rust/v10/src/main.rs` source uses the prost 0.13 API where
  `Message::encode` returns `Result`; with 0.14 `encode` is infallible so
  `inst.encode(&mut bytes).map_err(|e| …)` fails to compile (exit 101).

- **`itk/process_results.py`**: add `_check_itk_error()` that detects when the
  ITK service returns `{"detail":"…"}` (e.g. after a build failure) instead of
  a proper results payload, exits non-zero and avoids writing a misleading
  history entry with `"scenarios": []`.

## Test plan

- [ ] Trigger `workflow_dispatch` on `itk-nightly` workflow and verify
  `cargo build --release` succeeds inside the container
- [ ] Confirm `itk_rust.json` uploaded to the `nightly-metrics` release contains
  non-empty `scenarios` entries