### PR TITLE
ci: add itk path-ignore to non-ITK workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'itk/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,8 +3,12 @@ name: Publish Project Coverage to Codecov
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'itk/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'itk/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'itk/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

`itk/` is a standalone crate outside the workspace. Changes there should
not trigger unrelated workflows.

- **`ci.yml`** (`pull_request`): skip when only `itk/**` files changed
- **`coverage.yml`** (`push/PR → main`): skip when only `itk/**` files changed
- **`release-rust.yml`** (`push → main`): skip when only `itk/**` files changed

`itk-nightly.yaml` is schedule + `workflow_dispatch` only — path filtering
does not apply and no change is needed there.