### PR TITLE
fix(itk): declare standalone workspace to prevent parent workspace detection

### DIFF
--- a/itk/Cargo.toml
+++ b/itk/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 name = "itk-rust-current-agent"
 version = "0.1.0"


### PR DESCRIPTION
## Summary

Cargo walks up from `itk/` and finds the a2a-rs workspace root `Cargo.toml`,
then fails with:

```
error: current package believes it's in a workspace when it's not
```

because `itk/` is not listed in the workspace `members`. Adding `[workspace]`
at the top of `itk/Cargo.toml` makes it the root of its own isolated workspace
so Cargo stops the upward search.

Fixes the `cargo build --release` exit-101 failure seen in:
https://github.com/a2aproject/a2a-rs/actions/runs/27400710482

## Test plan

- [ ] Trigger `workflow_dispatch` on `itk-nightly` and verify `cargo build --release` succeeds