### PR TITLE
feat: add binary distribution for Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -1,0 +1,96 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Refresh Homebrew Formula
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: CLI release tag to render into Formula/a2acli.rb (e.g. a2a-cli-v0.1.5)
+        required: true
+        type: string
+
+jobs:
+  refresh-homebrew-formula:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'a2a-cli-v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve release tag
+        id: release
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ inputs.tag }}"
+          else
+            tag="${{ github.event.release.tag_name }}"
+          fi
+
+          case "$tag" in
+            a2a-cli-v*)
+              version="${tag#a2a-cli-v}"
+              ;;
+            *)
+              echo "::error::expected an a2a-cli-v* tag, got $tag"
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Render Homebrew formula
+        run: python scripts/render_homebrew_formula.py --tag "${{ steps.release.outputs.tag }}" --output Formula/a2acli.rb
+
+      - name: Open formula refresh PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet -- Formula/a2acli.rb; then
+            echo "Formula already up to date for ${{ steps.release.outputs.tag }}"
+            exit 0
+          fi
+
+          branch="automation/homebrew-a2acli-${{ steps.release.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          git add Formula/a2acli.rb
+          git commit -m "release: update Homebrew formula for a2acli v${{ steps.release.outputs.version }}"
+          git push --force --set-upstream origin "$branch"
+
+          pr_number=$(gh pr list --repo a2aproject/a2a-rs --head "$branch" --base main --state open --json number --jq 'first(.[].number) // ""')
+          if [ -n "$pr_number" ]; then
+            echo "Updated existing PR #$pr_number"
+            exit 0
+          fi
+
+          cat > /tmp/homebrew-formula-pr-body.md <<EOF
+          Update Formula/a2acli.rb for ${{ steps.release.outputs.tag }}.
+
+          - refreshes the source tarball SHA256
+          - keeps the Homebrew install path aligned with the latest CLI release
+          EOF
+
+          gh pr create \
+            --repo a2aproject/a2a-rs \
+            --base main \
+            --head "$branch" \
+            --title "release: update Homebrew formula for a2acli v${{ steps.release.outputs.version }}" \
+            --body-file /tmp/homebrew-formula-pr-body.md

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,84 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build a2acli Release Artifacts
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'itk/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'itk/**'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-a2acli-release-artifacts:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS arm64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+          - name: macOS x86_64
+            runner: macos-13
+            target: x86_64-apple-darwin
+          - name: Windows x86_64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        run: |
+          python scripts/resolve_a2acli_release_metadata.py \
+            --event-name "${{ github.event_name }}" \
+            --release-tag "" \
+            --target "${{ matrix.target }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Build a2acli
+        run: cargo build -p a2a-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package release archive
+        id: package
+        shell: bash
+        run: |
+          python scripts/package_a2acli_release.py \
+            --binary "${{ steps.metadata.outputs.binary_path }}" \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --output-dir dist \
+            --github-output "$GITHUB_OUTPUT"

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -12,6 +12,9 @@ jobs:
   release-crates:
     name: Release crates
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release-plz.outputs.releases_created }}
+      releases: ${{ steps.release-plz.outputs.releases }}
     permissions:
       contents: write
       pull-requests: read
@@ -26,6 +29,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
 
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5.128
         with:
           command: release
@@ -33,6 +37,161 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  resolve-a2acli-release:
+    name: Resolve a2acli release
+    needs: release-crates
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"a2a-cli"') }}
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release.outputs.release_tag }}
+    steps:
+      - name: Resolve CLI release tag
+        id: release
+        shell: bash
+        env:
+          RELEASES: ${{ needs.release-crates.outputs.releases }}
+        run: |
+          release_tag=$(python3 - <<'PY'
+          import json
+          import os
+
+          releases = json.loads(os.environ["RELEASES"])
+          for release in releases:
+              if release["package_name"] == "a2a-cli":
+                  print(release["tag"])
+                  break
+          else:
+              raise SystemExit("a2a-cli release not found in release-plz outputs")
+          PY
+          )
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+
+  release-a2acli-binaries:
+    name: Release a2acli binaries (${{ matrix.name }})
+    needs:
+      - release-crates
+      - resolve-a2acli-release
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"a2a-cli"') }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS arm64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+          - name: macOS x86_64
+            runner: macos-13
+            target: x86_64-apple-darwin
+          - name: Windows x86_64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        run: |
+          python scripts/resolve_a2acli_release_metadata.py \
+            --event-name release \
+            --release-tag "${{ needs.resolve-a2acli-release.outputs.release_tag }}" \
+            --target "${{ matrix.target }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Build a2acli
+        run: cargo build -p a2a-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package release archive
+        id: package
+        shell: bash
+        run: |
+          python scripts/package_a2acli_release.py \
+            --binary "${{ steps.metadata.outputs.binary_path }}" \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --output-dir dist \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ steps.metadata.outputs.release_tag }}" \
+            "${{ steps.package.outputs.archive_path }}" \
+            "${{ steps.package.outputs.checksum_path }}" \
+            --repo "${{ github.repository }}" \
+            --clobber
+
+  release-a2acli-winget:
+    name: Publish a2acli WinGet manifests
+    needs:
+      - release-crates
+      - resolve-a2acli-release
+      - release-a2acli-binaries
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"a2a-cli"') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-a2acli-release.outputs.release_tag }}
+    steps:
+      - name: Trigger WinGet manifest workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run winget-manifests.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f release_tag="$RELEASE_TAG"
+
+  release-a2acli-homebrew:
+    name: Publish a2acli Homebrew formula
+    needs:
+      - release-crates
+      - resolve-a2acli-release
+      - release-a2acli-binaries
+    if: ${{ needs.release-crates.outputs.releases_created == 'true' && contains(needs.release-crates.outputs.releases, '"package_name":"a2a-cli"') }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-a2acli-release.outputs.release_tag }}
+    steps:
+      - name: Trigger Homebrew formula workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run homebrew-formula.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f tag="$RELEASE_TAG"
 
   release-crates-pr:
     name: Release crates - PR

--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -1,0 +1,153 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Publish WinGet Manifests
+
+on:
+  workflow_call:
+    inputs:
+      release_tag:
+        description: CLI release tag to render into WinGet manifests
+        required: true
+        type: string
+    secrets:
+      PROJECT_APP_ID:
+        required: false
+      PROJECT_APP_KEY:
+        required: false
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: CLI release tag to render into WinGet manifests (e.g. a2a-cli-v0.1.5)
+        required: true
+        type: string
+
+jobs:
+  publish-winget-manifests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      APP_AUTH_CONFIGURED: ${{ secrets.PROJECT_APP_ID != '' && secrets.PROJECT_APP_KEY != '' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Render WinGet manifests
+        id: render
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/render_winget_manifests.py \
+            --tag "$RELEASE_TAG" \
+            --output-dir dist/winget \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload WinGet manifest artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: winget-manifests-${{ steps.render.outputs.package_version }}
+          path: dist/winget/manifests
+
+      - name: Authenticate with GitHub App Bot
+        if: env.APP_AUTH_CONFIGURED == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve GitHub App Bot user id
+        if: ${{ steps.app-token.outputs.token != '' }}
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "user_id=$(gh api '/users/${{ steps.app-token.outputs.app-slug }}[bot]' --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Open or update winget-pkgs PR
+        env:
+          WINGET_PKGS_TOKEN: ${{ steps.app-token.outputs.token }}
+          FORK_OWNER: ${{ github.repository_owner }}
+          GIT_AUTHOR_NAME: ${{ steps.app-token.outputs.app-slug }}[bot]
+          GIT_AUTHOR_EMAIL: ${{ steps.app-user.outputs.user_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
+          MANIFEST_DIR: ${{ steps.render.outputs.manifest_dir }}
+          MANIFEST_REL_DIR: ${{ steps.render.outputs.manifest_rel_dir }}
+          PACKAGE_IDENTIFIER: ${{ steps.render.outputs.package_identifier }}
+          PACKAGE_VERSION: ${{ steps.render.outputs.package_version }}
+          RELEASE_URL: ${{ steps.render.outputs.release_url }}
+        run: |
+          if [ -z "$WINGET_PKGS_TOKEN" ]; then
+            echo "::notice::PROJECT_APP_ID / PROJECT_APP_KEY are not configured; uploaded generated WinGet manifests as a workflow artifact only."
+            exit 0
+          fi
+
+          fork_owner="$FORK_OWNER"
+
+          if ! GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo view "$fork_owner/winget-pkgs" >/dev/null 2>&1; then
+            echo "::error::Expected an existing fork at $fork_owner/winget-pkgs. Create and maintain that fork before running this workflow."
+            exit 1
+          fi
+
+          export GH_TOKEN="$WINGET_PKGS_TOKEN"
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh auth setup-git >/dev/null
+
+          rm -rf /tmp/winget-pkgs
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh repo clone "$fork_owner/winget-pkgs" /tmp/winget-pkgs -- --depth 1
+
+          branch="automation/winget-a2acli-$PACKAGE_VERSION"
+
+          cd /tmp/winget-pkgs
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream https://github.com/microsoft/winget-pkgs.git
+          else
+            git remote add upstream https://github.com/microsoft/winget-pkgs.git
+          fi
+          git fetch --depth 1 upstream master
+          git config user.name "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
+          git checkout -B "$branch" upstream/master
+
+          mkdir -p "$(dirname "$MANIFEST_REL_DIR")"
+          rm -rf "$MANIFEST_REL_DIR"
+          cp -R "$MANIFEST_DIR" "$(dirname "$MANIFEST_REL_DIR")/"
+
+          git add --all "$MANIFEST_REL_DIR"
+
+          if git diff --cached --quiet -- "$MANIFEST_REL_DIR"; then
+            echo "WinGet manifests are already up to date for $RELEASE_TAG"
+            exit 0
+          fi
+
+          git commit -m "release: add WinGet manifest for a2acli v$PACKAGE_VERSION"
+          git push --force --set-upstream origin "$branch"
+
+          pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""')
+          if [ -n "$pr_number" ]; then
+            echo "Updated existing PR #$pr_number"
+            exit 0
+          fi
+
+          cat > /tmp/winget-pr-body.md <<EOF
+          Add WinGet manifests for $PACKAGE_IDENTIFIER $PACKAGE_VERSION.
+
+          - publishes the Windows portable ZIP for a2acli
+          - points WinGet at the a2a-rs GitHub release asset and checksum-backed digest
+          - generated from the a2a-rs CLI release automation
+
+          Upstream release: $RELEASE_URL
+          EOF
+
+          GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr create \
+            --repo microsoft/winget-pkgs \
+            --base master \
+            --head "$fork_owner:$branch" \
+            --title "Add WinGet manifest for a2aproject.a2acli version $PACKAGE_VERSION" \
+            --body-file /tmp/winget-pr-body.md

--- a/Formula/a2acli.rb
+++ b/Formula/a2acli.rb
@@ -1,0 +1,22 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+class A2acli < Formula
+  desc "Standalone A2A CLI client"
+  homepage "https://github.com/a2aproject/a2a-rs"
+  url "https://github.com/a2aproject/a2a-rs/archive/refs/tags/a2a-cli-v0.1.5.tar.gz"
+  sha256 "PLACEHOLDER"
+  license "Apache-2.0"
+  head "https://github.com/a2aproject/a2a-rs.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--locked", "--path", "a2acli", *std_cargo_args
+  end
+
+  test do
+    assert_match "a2acli", shell_output("#{bin}/a2acli --help")
+  end
+end

--- a/Formula/a2acli.rb
+++ b/Formula/a2acli.rb
@@ -5,7 +5,7 @@ class A2acli < Formula
   desc "Standalone A2A CLI client"
   homepage "https://github.com/a2aproject/a2a-rs"
   url "https://github.com/a2aproject/a2a-rs/archive/refs/tags/a2a-cli-v0.1.5.tar.gz"
-  sha256 "PLACEHOLDER"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
   license "Apache-2.0"
   head "https://github.com/a2aproject/a2a-rs.git", branch: "main"
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+#
+# Install a2acli — the A2A CLI tool (Linux only; macOS users: brew install a2aproject/a2acli)
+#
+# Usage:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/a2aproject/a2a-rs/main/install.sh)
+#
+# Environment overrides:
+#   A2A_CLI_VERSION              Install a specific version such as 0.1.5,
+#                                v0.1.5, or a2a-cli-v0.1.5.
+#   A2A_CLI_INSTALL_DIR          Directory to place the a2acli binary.
+#   A2A_CLI_RELEASE_API_URL      Override the releases metadata API URL.
+#   A2A_CLI_RELEASE_DOWNLOAD_BASE_URL  Override the release asset download base URL.
+
+set -euo pipefail
+
+REPO_OWNER="a2aproject"
+REPO_NAME="a2a-rs"
+RELEASE_PREFIX="a2a-cli-v"
+DEFAULT_RELEASE_API_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+DEFAULT_RELEASE_DOWNLOAD_BASE_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download"
+TARGET_X86_64="x86_64-unknown-linux-gnu"
+TARGET_ARM64="aarch64-unknown-linux-gnu"
+
+usage() {
+  cat <<'EOF'
+Install a2acli from published GitHub release assets.
+
+Usage:
+  bash install.sh
+
+Environment overrides:
+  A2A_CLI_VERSION                    Install a specific version such as 0.1.5,
+                                     v0.1.5, or a2a-cli-v0.1.5.
+  A2A_CLI_INSTALL_DIR                Directory to place the a2acli binary.
+  A2A_CLI_RELEASE_API_URL            Override the releases metadata API URL.
+  A2A_CLI_RELEASE_DOWNLOAD_BASE_URL  Override the release asset download base URL.
+EOF
+}
+
+log() {
+  printf '==> %s\n' "$*" >&2
+}
+
+warn() {
+  printf 'warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+have_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+require_cmd() {
+  have_cmd "$1" || die "$1 is required"
+}
+
+fetch_to_file() {
+  local url="$1"
+  local destination="$2"
+
+  if have_cmd curl; then
+    curl -fsSL --retry 3 "$url" -o "$destination"
+    return
+  fi
+
+  if have_cmd wget; then
+    wget -qO "$destination" "$url"
+    return
+  fi
+
+  die "curl or wget is required"
+}
+
+fetch_text() {
+  local url="$1"
+
+  if have_cmd curl; then
+    curl -fsSL --retry 3 -H 'Accept: application/vnd.github+json' "$url"
+    return
+  fi
+
+  if have_cmd wget; then
+    wget -qO- --header='Accept: application/vnd.github+json' "$url"
+    return
+  fi
+
+  die "curl or wget is required"
+}
+
+normalize_version() {
+  local requested="$1"
+
+  case "$requested" in
+    "${RELEASE_PREFIX}"*)
+      printf '%s\n' "${requested#${RELEASE_PREFIX}}"
+      ;;
+    v*)
+      printf '%s\n' "${requested#v}"
+      ;;
+    *)
+      printf '%s\n' "$requested"
+      ;;
+  esac
+}
+
+resolve_release_tag() {
+  if [[ -n "${A2A_CLI_VERSION:-}" ]]; then
+    local requested_version
+    requested_version="$(normalize_version "$A2A_CLI_VERSION")"
+    [[ -n "$requested_version" ]] || die "A2A_CLI_VERSION must not be empty"
+    printf '%s\n' "${RELEASE_PREFIX}${requested_version}"
+    return
+  fi
+
+  local api_url
+  api_url="${A2A_CLI_RELEASE_API_URL:-$DEFAULT_RELEASE_API_URL}"
+
+  local response
+  response="$(fetch_text "$api_url")"
+
+  # Releases are returned newest-first; find the first a2a-cli-v* tag
+  local tag
+  tag="$(printf '%s\n' "$response" \
+    | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"a2a-cli-v[^"]*"' \
+    | head -1 \
+    | grep -oE '"a2a-cli-v[^"]*"' \
+    | tr -d '"')"
+  [[ -n "$tag" ]] || die "failed to resolve the latest a2acli release tag from $api_url"
+  printf '%s\n' "$tag"
+}
+
+resolve_target() {
+  [[ "$(uname -s)" == "Linux" ]] || die "this installer only supports Linux hosts; macOS users: brew install a2aproject/a2acli"
+
+  case "$(uname -m)" in
+    x86_64|amd64)
+      printf '%s\n' "$TARGET_X86_64"
+      ;;
+    aarch64|arm64)
+      printf '%s\n' "$TARGET_ARM64"
+      ;;
+    *)
+      die "unsupported Linux architecture $(uname -m); supported targets are x86_64 and aarch64"
+      ;;
+  esac
+}
+
+resolve_install_dir() {
+  if [[ -n "${A2A_CLI_INSTALL_DIR:-}" ]]; then
+    printf '%s\n' "$A2A_CLI_INSTALL_DIR"
+    return
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    printf '/usr/local/bin\n'
+    return
+  fi
+
+  if [[ -n "${XDG_BIN_HOME:-}" ]]; then
+    printf '%s\n' "$XDG_BIN_HOME"
+    return
+  fi
+
+  printf '%s/.local/bin\n' "$HOME"
+}
+
+compute_sha256() {
+  local path="$1"
+
+  if have_cmd sha256sum; then
+    sha256sum "$path" | awk '{print $1}'
+    return
+  fi
+
+  if have_cmd shasum; then
+    shasum -a 256 "$path" | awk '{print $1}'
+    return
+  fi
+
+  if have_cmd openssl; then
+    openssl dgst -sha256 "$path" | awk '{print $NF}'
+    return
+  fi
+
+  die "sha256sum, shasum, or openssl is required"
+}
+
+cleanup() {
+  if [[ -n "${work_dir:-}" && -d "${work_dir:-}" ]]; then
+    rm -rf "$work_dir"
+  fi
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+require_cmd tar
+require_cmd mktemp
+require_cmd install
+require_cmd mv
+
+release_tag="$(resolve_release_tag)"
+version="${release_tag#${RELEASE_PREFIX}}"
+target="$(resolve_target)"
+install_dir="$(resolve_install_dir)"
+release_download_base_url="${A2A_CLI_RELEASE_DOWNLOAD_BASE_URL:-$DEFAULT_RELEASE_DOWNLOAD_BASE_URL}"
+release_dir_url="${release_download_base_url%/}/${release_tag}"
+archive_name="a2acli-v${version}-${target}.tar.gz"
+checksum_name="${archive_name}.sha256"
+archive_url="${release_dir_url}/${archive_name}"
+checksum_url="${release_dir_url}/${checksum_name}"
+
+work_dir="$(mktemp -d)"
+trap cleanup EXIT
+
+archive_path="${work_dir}/${archive_name}"
+checksum_path="${work_dir}/${checksum_name}"
+extract_dir="${work_dir}/extract"
+
+log "downloading ${archive_name}"
+fetch_to_file "$archive_url" "$archive_path"
+
+log "downloading ${checksum_name}"
+fetch_to_file "$checksum_url" "$checksum_path"
+
+expected_sha="$(awk 'NF { print $1; exit }' "$checksum_path" | tr '[:upper:]' '[:lower:]')"
+actual_sha="$(compute_sha256 "$archive_path" | tr '[:upper:]' '[:lower:]')"
+[[ -n "$expected_sha" ]] || die "checksum file ${checksum_name} did not contain a SHA-256 value"
+[[ "$expected_sha" == "$actual_sha" ]] || die "downloaded archive checksum mismatch"
+
+log "verified ${archive_name}"
+
+mkdir -p "$extract_dir"
+tar -xzf "$archive_path" -C "$extract_dir"
+
+archive_stem="a2acli-v${version}-${target}"
+binary_path="${extract_dir}/${archive_stem}/a2acli"
+[[ -f "$binary_path" ]] || die "release archive did not contain ${archive_stem}/a2acli"
+
+mkdir -p "$install_dir" || die "could not create ${install_dir}; rerun with sudo or set A2A_CLI_INSTALL_DIR"
+[[ -w "$install_dir" ]] || die "could not write to ${install_dir}; rerun with sudo or set A2A_CLI_INSTALL_DIR"
+
+destination="${install_dir}/a2acli"
+staged_destination="${install_dir}/.a2acli.tmp.$$"
+
+install -m 0755 "$binary_path" "$staged_destination"
+mv "$staged_destination" "$destination"
+
+log "installed a2acli ${version} to ${destination}"
+
+case ":${PATH}:" in
+  *":${install_dir}:"*)
+    ;;
+  *)
+    warn "${install_dir} is not on PATH"
+    warn "add it with: export PATH=\"${install_dir}:\$PATH\""
+    ;;
+esac

--- a/install.sh
+++ b/install.sh
@@ -131,7 +131,7 @@ resolve_release_tag() {
     | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"a2a-cli-v[^"]*"' \
     | head -1 \
     | grep -oE '"a2a-cli-v[^"]*"' \
-    | tr -d '"')"
+    | tr -d '"' || true)"
   [[ -n "$tag" ]] || die "failed to resolve the latest a2acli release tag from $api_url"
   printf '%s\n' "$tag"
 }
@@ -250,7 +250,7 @@ mkdir -p "$install_dir" || die "could not create ${install_dir}; rerun with sudo
 [[ -w "$install_dir" ]] || die "could not write to ${install_dir}; rerun with sudo or set A2A_CLI_INSTALL_DIR"
 
 destination="${install_dir}/a2acli"
-staged_destination="${install_dir}/.a2acli.tmp.$$"
+staged_destination="$(mktemp "${install_dir}/.a2acli.tmp.XXXXXX")"
 
 install -m 0755 "$binary_path" "$staged_destination"
 mv "$staged_destination" "$destination"

--- a/scripts/package_a2acli_release.py
+++ b/scripts/package_a2acli_release.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import shutil
+import tarfile
+import zipfile
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT_DIR = ROOT / "dist"
+DEFAULT_LICENSE = ROOT / "LICENSE.md"
+DEFAULT_README = ROOT / "README.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Package a built a2acli binary into a release archive."
+    )
+    parser.add_argument(
+        "--binary",
+        type=Path,
+        required=True,
+        help="Path to the built a2acli binary.",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Rust target triple used to build the binary.",
+    )
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="CLI version used in the release archive name.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Directory for generated archives (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--license",
+        type=Path,
+        default=DEFAULT_LICENSE,
+        help=f"License file to include in the archive (default: {DEFAULT_LICENSE}).",
+    )
+    parser.add_argument(
+        "--readme",
+        type=Path,
+        default=DEFAULT_README,
+        help=f"README file to include in the archive (default: {DEFAULT_README}).",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Optional GitHub Actions output file to append archive metadata to.",
+    )
+    return parser.parse_args()
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_github_output(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def add_directory_to_zip(archive: Path, directory: Path) -> None:
+    with zipfile.ZipFile(archive, "w", compression=zipfile.ZIP_DEFLATED) as handle:
+        for path in sorted(directory.rglob("*")):
+            if path.is_dir():
+                continue
+            handle.write(path, arcname=path.relative_to(directory.parent))
+
+
+def add_directory_to_targz(archive: Path, directory: Path) -> None:
+    with tarfile.open(archive, "w:gz") as handle:
+        handle.add(directory, arcname=directory.name)
+
+
+def main() -> None:
+    args = parse_args()
+
+    binary = args.binary.resolve()
+    if not binary.is_file():
+        raise SystemExit(f"expected built binary at {binary}")
+
+    for support_path in (args.license, args.readme):
+        if not support_path.is_file():
+            raise SystemExit(f"expected support file at {support_path}")
+
+    archive_stem = f"a2acli-v{args.version}-{args.target}"
+    output_dir = args.output_dir.resolve()
+    staging_dir = output_dir / archive_stem
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir()
+
+    binary_name = "a2acli.exe" if args.target.endswith("windows-msvc") else "a2acli"
+    shutil.copy2(binary, staging_dir / binary_name)
+    shutil.copy2(args.license, staging_dir / args.license.name)
+    shutil.copy2(args.readme, staging_dir / args.readme.name)
+
+    if args.target.endswith("windows-msvc"):
+        archive_path = output_dir / f"{archive_stem}.zip"
+        add_directory_to_zip(archive_path, staging_dir)
+    else:
+        archive_path = output_dir / f"{archive_stem}.tar.gz"
+        add_directory_to_targz(archive_path, staging_dir)
+
+    checksum_path = output_dir / f"{archive_path.name}.sha256"
+    checksum_path.write_text(
+        f"{sha256(archive_path)}  {archive_path.name}\n",
+        encoding="utf-8",
+    )
+
+    shutil.rmtree(staging_dir)
+
+    outputs = {
+        "archive_stem": archive_stem,
+        "archive_path": str(archive_path),
+        "checksum_path": str(checksum_path),
+    }
+    if args.github_output is not None:
+        write_github_output(args.github_output, outputs)
+
+    for key, value in outputs.items():
+        print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import re
+import textwrap
+import tomllib
+import urllib.request
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
+CLI_MANIFEST = ROOT / "a2acli" / "Cargo.toml"
+DEFAULT_OUTPUT = ROOT / "Formula" / "a2acli.rb"
+TAG_PATTERN = re.compile(r"^a2a-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
+FORMULA_HEADER = textwrap.dedent(
+    """\
+    # Copyright AGNTCY Contributors (https://github.com/agntcy)
+    # SPDX-License-Identifier: Apache-2.0
+
+    """
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render the Homebrew formula for the released a2acli tag."
+    )
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help="Release tag in the form a2a-cli-v<version>",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help=f"Formula output path (default: {DEFAULT_OUTPUT})",
+    )
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def resolve_workspace_value(package: dict, workspace_package: dict, key: str) -> str:
+    value = package.get(key)
+    if isinstance(value, dict) and value.get("workspace"):
+        return workspace_package[key]
+    if value is None:
+        return workspace_package[key]
+    if not isinstance(value, str):
+        raise SystemExit(f"expected {key} to resolve to a string")
+    return value
+
+
+def fetch_sha256(url: str) -> str:
+    request = urllib.request.Request(url, headers={"User-Agent": "a2aproject-release-automation"})
+    digest = hashlib.sha256()
+    with urllib.request.urlopen(request, timeout=60) as response:
+        while True:
+            chunk = response.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ruby_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def render_formula(tag: str) -> str:
+    match = TAG_PATTERN.match(tag)
+    if not match:
+        raise SystemExit(f"expected a2a-cli-v<version> tag, got: {tag}")
+
+    workspace = load_toml(WORKSPACE_MANIFEST)
+    cli_manifest = load_toml(CLI_MANIFEST)
+    workspace_package = workspace["workspace"]["package"]
+    package = cli_manifest["package"]
+
+    description = package["description"]
+    homepage = resolve_workspace_value(package, workspace_package, "repository")
+    license_id = resolve_workspace_value(package, workspace_package, "license")
+    source_url = f"{homepage}/archive/refs/tags/{tag}.tar.gz"
+    source_sha256 = fetch_sha256(source_url)
+    git_url = homepage if homepage.endswith(".git") else f"{homepage}.git"
+
+    formula_body = textwrap.dedent(
+        f"""\
+        class A2acli < Formula
+          desc \"{ruby_string(description)}\"
+          homepage \"{ruby_string(homepage)}\"
+          url \"{ruby_string(source_url)}\"
+          sha256 \"{source_sha256}\"
+          license \"{ruby_string(license_id)}\"
+          head \"{ruby_string(git_url)}\", branch: \"main\"
+
+          depends_on \"cmake\" => :build
+          depends_on \"rust\" => :build
+
+          def install
+            system \"cargo\", \"install\", \"--locked\", \"--path\", \"a2acli\", *std_cargo_args
+          end
+
+          test do
+            assert_match \"a2acli\", shell_output(\"#{{bin}}/a2acli --help\")
+          end
+        end
+        """
+    )
+
+    return f"{FORMULA_HEADER}{formula_body}"
+
+
+def main() -> int:
+    args = parse_args()
+    formula = render_formula(args.tag)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(formula, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import re
 import textwrap
 import tomllib
+import urllib.error
 import urllib.request
 
 
@@ -64,12 +65,16 @@ def resolve_workspace_value(package: dict, workspace_package: dict, key: str) ->
 def fetch_sha256(url: str) -> str:
     request = urllib.request.Request(url, headers={"User-Agent": "a2aproject-release-automation"})
     digest = hashlib.sha256()
-    with urllib.request.urlopen(request, timeout=60) as response:
-        while True:
-            chunk = response.read(1024 * 1024)
-            if not chunk:
-                break
-            digest.update(chunk)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except urllib.error.URLError as error:
+        reason = f"HTTP {error.code}" if isinstance(error, urllib.error.HTTPError) else error.reason
+        raise SystemExit(f"failed to fetch {url}: {reason}") from error
     return digest.hexdigest()
 
 

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+import textwrap
+import tomllib
+import urllib.request
+from urllib.error import HTTPError
+
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
+CLI_MANIFEST = ROOT / "a2acli" / "Cargo.toml"
+DEFAULT_OUTPUT_DIR = ROOT / "dist" / "winget"
+
+MANIFEST_VERSION = "1.12.0"
+PACKAGE_IDENTIFIER = "a2aproject.a2acli"
+PACKAGE_LOCALE = "en-US"
+PUBLISHER = "a2aproject"
+PACKAGE_NAME = "a2acli"
+MONIKER = "a2acli"
+WINDOWS_ARCHITECTURE = "x64"
+WINDOWS_TARGET = "x86_64-pc-windows-msvc"
+TAG_PATTERN = re.compile(r"^a2a-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
+REPOSITORY_PATTERN = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$"
+)
+
+
+@dataclass(frozen=True)
+class ReleaseAssets:
+    tag: str
+    version: str
+    release_date: str
+    release_url: str
+    installer_url: str
+    installer_sha256: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render WinGet manifests for a released a2acli tag."
+    )
+    parser.add_argument(
+        "--tag",
+        required=True,
+        help="Release tag in the form a2a-cli-v<version>",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Output root for generated manifests (default: {DEFAULT_OUTPUT_DIR}).",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Optional GitHub Actions output file to append manifest metadata to.",
+    )
+    return parser.parse_args()
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def resolve_workspace_value(package: dict, workspace_package: dict, key: str) -> str:
+    value = package.get(key)
+    if isinstance(value, dict) and value.get("workspace"):
+        return workspace_package[key]
+    if value is None:
+        return workspace_package[key]
+    if not isinstance(value, str):
+        raise SystemExit(f"expected {key} to resolve to a string")
+    return value
+
+
+def github_headers() -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "a2aproject-release-automation",
+    }
+    token = None
+    for env_var in ("GITHUB_TOKEN", "GH_TOKEN"):
+        if env_var in os.environ and os.environ[env_var]:
+            token = os.environ[env_var]
+            break
+    if token is not None:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def fetch_bytes(url: str) -> bytes:
+    request = urllib.request.Request(url, headers=github_headers())
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read()
+    except HTTPError as error:
+        raise SystemExit(f"failed to fetch {url}: HTTP {error.code}") from error
+
+
+def fetch_json(url: str) -> dict:
+    return json.loads(fetch_bytes(url))
+
+
+def fetch_text(url: str) -> str:
+    return fetch_bytes(url).decode("utf-8")
+
+
+def sha256_for_url(url: str) -> str:
+    request = urllib.request.Request(url, headers=github_headers())
+    digest = hashlib.sha256()
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                digest.update(chunk)
+    except HTTPError as error:
+        raise SystemExit(f"failed to fetch {url}: HTTP {error.code}") from error
+    return digest.hexdigest().upper()
+
+
+def parse_repository_slug(repository_url: str) -> str:
+    match = REPOSITORY_PATTERN.match(repository_url)
+    if not match:
+        raise SystemExit(f"expected GitHub repository URL, got: {repository_url}")
+    return f"{match.group('owner')}/{match.group('repo')}"
+
+
+def parse_release_tag(tag: str) -> str:
+    match = TAG_PATTERN.match(tag)
+    if not match:
+        raise SystemExit(f"expected a2a-cli-v<version> tag, got: {tag}")
+    return match.group("version")
+
+
+def resolve_release_assets(tag: str, repository_slug: str) -> ReleaseAssets:
+    version = parse_release_tag(tag)
+    release = fetch_json(
+        f"https://api.github.com/repos/{repository_slug}/releases/tags/{tag}"
+    )
+
+    installer_name = f"a2acli-v{version}-{WINDOWS_TARGET}.zip"
+    checksum_name = f"{installer_name}.sha256"
+
+    installer_url = None
+    checksum_url = None
+    for asset in release.get("assets", []):
+        asset_name = asset.get("name")
+        asset_url = asset.get("browser_download_url")
+        if asset_name == installer_name:
+            installer_url = asset_url
+        elif asset_name == checksum_name:
+            checksum_url = asset_url
+
+    if installer_url is None:
+        raise SystemExit(
+            f"release {tag} does not contain the expected Windows asset {installer_name}"
+        )
+
+    if checksum_url is not None:
+        checksum_text = fetch_text(checksum_url)
+        checksum_lines = [line.strip() for line in checksum_text.splitlines() if line.strip()]
+        if not checksum_lines:
+            raise SystemExit(f"checksum asset {checksum_name} is empty")
+        installer_sha256 = checksum_lines[0].split()[0].upper()
+    else:
+        installer_sha256 = sha256_for_url(installer_url)
+
+    release_date = release.get("published_at") or release.get("created_at")
+    if release_date is None:
+        raise SystemExit(f"release {tag} does not expose a publication date")
+
+    return ReleaseAssets(
+        tag=tag,
+        version=version,
+        release_date=release_date[:10],
+        release_url=release["html_url"],
+        installer_url=installer_url,
+        installer_sha256=installer_sha256,
+    )
+
+
+def render_version_manifest(version: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.{MANIFEST_VERSION}.schema.json
+
+        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageVersion: {version}
+        DefaultLocale: {PACKAGE_LOCALE}
+        ManifestType: version
+        ManifestVersion: {MANIFEST_VERSION}
+        """
+    )
+
+
+def render_default_locale_manifest(
+    *,
+    tag: str,
+    version: str,
+    description: str,
+    repository_url: str,
+    license_id: str,
+) -> str:
+    tags = "\n".join(
+        [
+            "Tags:",
+            "- a2a",
+            "- agent",
+            "- cli",
+            "- llm",
+            "- protocol",
+        ]
+    )
+    return textwrap.dedent(
+        f"""\
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.{MANIFEST_VERSION}.schema.json
+
+        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageVersion: {version}
+        PackageLocale: {PACKAGE_LOCALE}
+        Publisher: {PUBLISHER}
+        PublisherUrl: https://github.com/a2aproject
+        PublisherSupportUrl: {repository_url}/issues
+        Author: AGNTCY Contributors
+        PackageName: {PACKAGE_NAME}
+        PackageUrl: {repository_url}
+        License: {license_id}
+        LicenseUrl: {repository_url}/blob/{tag}/LICENSE.md
+        ShortDescription: {description}
+        Moniker: {MONIKER}
+        {tags}
+        ReleaseNotesUrl: {repository_url}/releases/tag/{tag}
+        ManifestType: defaultLocale
+        ManifestVersion: {MANIFEST_VERSION}
+        """
+    )
+
+
+def render_installer_manifest(release_assets: ReleaseAssets) -> str:
+    relative_file_path = (
+        f"a2acli-v{release_assets.version}-{WINDOWS_TARGET}\\a2acli.exe"
+    )
+    return textwrap.dedent(
+        f"""\
+        # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.{MANIFEST_VERSION}.schema.json
+
+        PackageIdentifier: {PACKAGE_IDENTIFIER}
+        PackageVersion: {release_assets.version}
+        InstallerType: zip
+        NestedInstallerType: portable
+        Commands:
+        - {MONIKER}
+        ReleaseDate: {release_assets.release_date}
+        Installers:
+        - Architecture: {WINDOWS_ARCHITECTURE}
+          InstallerUrl: {release_assets.installer_url}
+          InstallerSha256: {release_assets.installer_sha256}
+          NestedInstallerFiles:
+          - RelativeFilePath: {relative_file_path}
+            PortableCommandAlias: {MONIKER}
+        ManifestType: installer
+        ManifestVersion: {MANIFEST_VERSION}
+        """
+    )
+
+
+def manifest_directory(output_dir: Path, package_identifier: str, version: str) -> Path:
+    identifier_parts = package_identifier.split(".")
+    return output_dir / "manifests" / identifier_parts[0].lower()[0] / Path(*identifier_parts) / version
+
+
+def write_github_output(path: Path, values: dict[str, str]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main() -> int:
+    args = parse_args()
+
+    workspace = load_toml(WORKSPACE_MANIFEST)
+    cli_manifest = load_toml(CLI_MANIFEST)
+    workspace_package = workspace["workspace"]["package"]
+    package = cli_manifest["package"]
+
+    repository_url = resolve_workspace_value(package, workspace_package, "repository")
+    repository_slug = parse_repository_slug(repository_url)
+    description = package["description"]
+    license_id = resolve_workspace_value(package, workspace_package, "license")
+
+    release_assets = resolve_release_assets(args.tag, repository_slug)
+
+    output_dir = args.output_dir.resolve()
+    manifests_dir = manifest_directory(output_dir, PACKAGE_IDENTIFIER, release_assets.version)
+    if manifests_dir.exists():
+        shutil.rmtree(manifests_dir)
+    manifests_dir.mkdir(parents=True, exist_ok=True)
+
+    (manifests_dir / f"{PACKAGE_IDENTIFIER}.yaml").write_text(
+        render_version_manifest(release_assets.version),
+        encoding="utf-8",
+    )
+    (manifests_dir / f"{PACKAGE_IDENTIFIER}.locale.{PACKAGE_LOCALE}.yaml").write_text(
+        render_default_locale_manifest(
+            tag=release_assets.tag,
+            version=release_assets.version,
+            description=description,
+            repository_url=repository_url,
+            license_id=license_id,
+        ),
+        encoding="utf-8",
+    )
+    (manifests_dir / f"{PACKAGE_IDENTIFIER}.installer.yaml").write_text(
+        render_installer_manifest(release_assets),
+        encoding="utf-8",
+    )
+
+    outputs = {
+        "manifest_dir": str(manifests_dir),
+        "manifest_rel_dir": manifests_dir.relative_to(output_dir).as_posix(),
+        "package_identifier": PACKAGE_IDENTIFIER,
+        "package_version": release_assets.version,
+        "release_url": release_assets.release_url,
+    }
+    if args.github_output is not None:
+        write_github_output(args.github_output, outputs)
+
+    for key, value in outputs.items():
+        print(f"{key}={value}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import textwrap
 import tomllib
 import urllib.request
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -106,8 +106,9 @@ def fetch_bytes(url: str) -> bytes:
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
             return response.read()
-    except HTTPError as error:
-        raise SystemExit(f"failed to fetch {url}: HTTP {error.code}") from error
+    except URLError as error:
+        reason = f"HTTP {error.code}" if isinstance(error, HTTPError) else error.reason
+        raise SystemExit(f"failed to fetch {url}: {reason}") from error
 
 
 def fetch_json(url: str) -> dict:
@@ -128,8 +129,9 @@ def sha256_for_url(url: str) -> str:
                 if not chunk:
                     break
                 digest.update(chunk)
-    except HTTPError as error:
-        raise SystemExit(f"failed to fetch {url}: HTTP {error.code}") from error
+    except URLError as error:
+        reason = f"HTTP {error.code}" if isinstance(error, HTTPError) else error.reason
+        raise SystemExit(f"failed to fetch {url}: {reason}") from error
     return digest.hexdigest().upper()
 
 

--- a/scripts/resolve_a2acli_release_metadata.py
+++ b/scripts/resolve_a2acli_release_metadata.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import tomllib
+
+
+ROOT = Path(__file__).resolve().parent.parent
+CLI_MANIFEST = ROOT / "a2acli" / "Cargo.toml"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Resolve a2acli release metadata for the GitHub Actions workflow."
+    )
+    parser.add_argument(
+        "--event-name",
+        required=True,
+        help="GitHub event name for the current workflow run.",
+    )
+    parser.add_argument(
+        "--release-tag",
+        default="",
+        help="GitHub release tag when the workflow is running for a published release.",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Rust target triple used to build a2acli.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        required=True,
+        help="GitHub Actions output file path.",
+    )
+    return parser.parse_args()
+
+
+def load_version() -> str:
+    with CLI_MANIFEST.open("rb") as handle:
+        manifest = tomllib.load(handle)
+    return manifest["package"]["version"]
+
+
+def resolve_release_tag(event_name: str, release_tag: str, version: str) -> str:
+    if event_name != "release":
+        return ""
+
+    prefix = "a2a-cli-v"
+    if not release_tag.startswith(prefix):
+        raise SystemExit(f"expected {prefix}<version>, got {release_tag}")
+
+    tag_version = release_tag[len(prefix):]
+    if tag_version != version:
+        raise SystemExit(
+            f"release tag version {tag_version} does not match a2acli/Cargo.toml version {version}"
+        )
+
+    return release_tag
+
+
+def resolve_binary_path(target: str) -> str:
+    binary_path = f"target/{target}/release/a2acli"
+    if target.endswith("windows-msvc"):
+        return f"{binary_path}.exe"
+    return binary_path
+
+
+def main() -> None:
+    args = parse_args()
+
+    version = load_version()
+    release_tag = resolve_release_tag(args.event_name, args.release_tag, version)
+
+    outputs = {
+        "version": version,
+        "release_tag": release_tag,
+        "binary_path": resolve_binary_path(args.target),
+    }
+
+    with args.github_output.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add pre-built binary distribution for a2acli modeled after agntcy/shadi:

- CI validation build on PR/push (5 targets, native runners)
- Release pipeline driven by release-plz outputs (binaries uploaded only when a2a-cli is actually released)
- `install.sh` for Linux (x86_64 / aarch64), with SHA-256 verification and atomic install
- Homebrew formula (`Formula/a2acli.rb`) auto-refreshed on each release via `homebrew-formula.yml`
- WinGet manifests generated by Python script and submitted to `microsoft/winget-pkgs` via `winget-manifests.yml`
- Python scripts mirror the shadi packaging approach: per-archive `.sha256` files, LICENSE + README bundled in archives