### PR TITLE
chore(a2acli): bump version to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "a2a-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",

--- a/a2acli/Cargo.toml
+++ b/a2acli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2a-cli"
-version = "0.1.5"
+version = "0.1.6"
 description = "Standalone A2A CLI client"
 readme = "README.md"
 edition.workspace = true


### PR DESCRIPTION
Bump a2a-cli version to 0.1.6 to trigger the binary release pipeline end-to-end.