### PR TITLE
fix(ci): cross-compile x86_64-apple-darwin on macos-latest

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -34,7 +34,7 @@ jobs:
             runner: macos-latest
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-13
+            runner: macos-latest
             target: x86_64-apple-darwin
           - name: Windows x86_64
             runner: windows-latest

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -90,7 +90,7 @@ jobs:
             runner: macos-latest
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-13
+            runner: macos-latest
             target: x86_64-apple-darwin
           - name: Windows x86_64
             runner: windows-latest


### PR DESCRIPTION
macos-13 (Intel) runners have chronic queue issues and are being sunset. Switch to cross-compiling x86_64-apple-darwin on the ARM macos-latest runner, which macOS supports natively.