### PR TITLE
ci: use GitHub App token for Homebrew formula PRs

### DIFF
--- a/.github/workflows/homebrew-formula.yml
+++ b/.github/workflows/homebrew-formula.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      APP_AUTH_CONFIGURED: ${{ secrets.PROJECT_APP_ID != '' && secrets.PROJECT_APP_KEY != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -56,11 +58,32 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Render Homebrew formula
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: python scripts/render_homebrew_formula.py --tag "${{ steps.release.outputs.tag }}" --output Formula/a2acli.rb
+
+      - name: Authenticate with GitHub App Bot
+        if: env.APP_AUTH_CONFIGURED == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.PROJECT_APP_ID }}
+          private-key: ${{ secrets.PROJECT_APP_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve GitHub App Bot user id
+        if: ${{ steps.app-token.outputs.token != '' }}
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          echo "user_id=$(gh api '/users/${{ steps.app-token.outputs.app-slug }}[bot]' --jq .id)" >> "$GITHUB_OUTPUT"
 
       - name: Open formula refresh PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GIT_AUTHOR_NAME: ${{ steps.app-token.outputs.app-slug != '' && format('{0}[bot]', steps.app-token.outputs.app-slug) || 'github-actions[bot]' }}
+          GIT_AUTHOR_EMAIL: ${{ steps.app-user.outputs.user_id != '' && format('{0}+{1}[bot]@users.noreply.github.com', steps.app-user.outputs.user_id, steps.app-token.outputs.app-slug) || '41898282+github-actions[bot]@users.noreply.github.com' }}
         run: |
           if git diff --quiet -- Formula/a2acli.rb; then
             echo "Formula already up to date for ${{ steps.release.outputs.tag }}"
@@ -68,8 +91,8 @@ jobs:
           fi
 
           branch="automation/homebrew-a2acli-${{ steps.release.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "$GIT_AUTHOR_NAME"
+          git config user.email "$GIT_AUTHOR_EMAIL"
           git checkout -B "$branch"
           git add Formula/a2acli.rb
           git commit -m "release: update Homebrew formula for a2acli v${{ steps.release.outputs.version }}"

--- a/.github/workflows/release-upload-binaries.yml
+++ b/.github/workflows/release-upload-binaries.yml
@@ -1,0 +1,93 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
+name: Upload a2acli Release Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to upload binaries for (e.g. a2a-cli-v0.1.6)"
+        required: true
+        type: string
+
+jobs:
+  upload-a2acli-binaries:
+    name: Upload a2acli binaries (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: Linux arm64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - name: macOS arm64
+            runner: macos-latest
+            target: aarch64-apple-darwin
+          - name: macOS x86_64
+            runner: macos-latest
+            target: x86_64-apple-darwin
+          - name: Windows x86_64
+            runner: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.release_tag }}
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@2b1f5e9b395427c92ee4e3331786ca3c37afe2d7 # v1.16.0
+        with:
+          target: ${{ matrix.target }}
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Resolve release metadata
+        id: metadata
+        shell: bash
+        run: |
+          python scripts/resolve_a2acli_release_metadata.py \
+            --event-name release \
+            --release-tag "${{ inputs.release_tag }}" \
+            --target "${{ matrix.target }}" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Build a2acli
+        run: cargo build -p a2a-cli --release --locked --target ${{ matrix.target }}
+
+      - name: Package release archive
+        id: package
+        shell: bash
+        run: |
+          python scripts/package_a2acli_release.py \
+            --binary "${{ steps.metadata.outputs.binary_path }}" \
+            --target "${{ matrix.target }}" \
+            --version "${{ steps.metadata.outputs.version }}" \
+            --output-dir dist \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release upload "${{ inputs.release_tag }}" \
+            "${{ steps.package.outputs.archive_path }}" \
+            "${{ steps.package.outputs.checksum_path }}" \
+            --repo "${{ github.repository }}" \
+            --clobber


### PR DESCRIPTION
PRs opened by `github-actions[bot]` (via `GITHUB_TOKEN`) do not trigger CI. This fixes the Homebrew formula update flow by using the `PROJECT_APP_ID`/`PROJECT_APP_KEY` GitHub App token (same pattern already used in `winget-manifests.yml`) to commit and open the PR as the App bot instead.

Also adds `release-upload-binaries.yml`: a `workflow_dispatch` workflow that builds and uploads all 5 binary targets for a given release tag, enabling manual re-uploads when a platform asset is missing.

## Changes
- `homebrew-formula.yml`: optionally authenticate with GitHub App; use App token for git author and `gh pr create`; falls back to `GITHUB_TOKEN` when App secrets are not configured
- `release-upload-binaries.yml`: new manual workflow with `release_tag` input, same 5-target matrix as the release pipeline