### PR TITLE
fix(homebrew): remove duplicate --locked flag from cargo install

### DIFF
--- a/Formula/a2acli.rb
+++ b/Formula/a2acli.rb
@@ -13,7 +13,7 @@ class A2acli < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", "--locked", "--path", "a2acli", *std_cargo_args
+    system "cargo", "install", "--path", "a2acli", *std_cargo_args
   end
 
   test do

--- a/Formula/a2acli.rb
+++ b/Formula/a2acli.rb
@@ -13,7 +13,7 @@ class A2acli < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", "--path", "a2acli", *std_cargo_args
+    system "cargo", "install", *std_cargo_args(path: "a2acli")
   end
 
   test do

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -113,7 +113,7 @@ def render_formula(tag: str) -> str:
           depends_on \"rust\" => :build
 
           def install
-            system \"cargo\", \"install\", \"--path\", \"a2acli\", *std_cargo_args
+            system \"cargo\", \"install\", *std_cargo_args(path: \"a2acli\")
           end
 
           test do

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -113,7 +113,7 @@ def render_formula(tag: str) -> str:
           depends_on \"rust\" => :build
 
           def install
-            system \"cargo\", \"install\", \"--locked\", \"--path\", \"a2acli\", *std_cargo_args
+            system \"cargo\", \"install\", \"--path\", \"a2acli\", *std_cargo_args
           end
 
           test do


### PR DESCRIPTION
\`std_cargo_args\` already includes \`--locked\`; the explicit \`--locked\` in the \`system\` call caused \`cargo install\` to fail with:

> error: the argument '--locked' cannot be used multiple times

Fixes both the live formula and the render script so future releases don't repeat the issue.