### PR TITLE
fix(winget): use WINGET_PAT for cross-org PR to microsoft/winget-pkgs

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -75,6 +75,7 @@ jobs:
       - name: Open or update winget-pkgs PR
         env:
           WINGET_PKGS_TOKEN: ${{ steps.app-token.outputs.token }}
+          WINGET_PAT: ${{ secrets.WINGET_PAT }}
           FORK_OWNER: ${{ github.repository_owner }}
           GIT_AUTHOR_NAME: ${{ steps.app-token.outputs.app-slug }}[bot]
           GIT_AUTHOR_EMAIL: ${{ steps.app-user.outputs.user_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
@@ -129,7 +130,11 @@ jobs:
           git commit -m "release: add WinGet manifest for a2acli v$PACKAGE_VERSION"
           git push --force --set-upstream origin "$branch"
 
-          pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""')
+          # Use WINGET_PAT for cross-org PR creation if available; App tokens are
+          # scoped to the installed org and cannot open PRs on microsoft/winget-pkgs.
+          pr_token="${WINGET_PAT:-$WINGET_PKGS_TOKEN}"
+
+          pr_number=$(GH_TOKEN="$pr_token" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""')
           if [ -n "$pr_number" ]; then
             echo "Updated existing PR #$pr_number"
             exit 0
@@ -145,7 +150,12 @@ jobs:
           Upstream release: $RELEASE_URL
           EOF
 
-          GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr create \
+          if [ -z "$WINGET_PAT" ]; then
+            echo "::notice::WINGET_PAT is not set; manifests pushed to fork but PR to microsoft/winget-pkgs was skipped. Set WINGET_PAT (classic PAT, public_repo scope) to enable automatic PR submission."
+            exit 0
+          fi
+
+          GH_TOKEN="$WINGET_PAT" gh pr create \
             --repo microsoft/winget-pkgs \
             --base master \
             --head "$fork_owner:$branch" \


### PR DESCRIPTION
GitHub App tokens are scoped to the org they're installed in and cannot open PRs on `microsoft/winget-pkgs`.

## Changes
- Add `WINGET_PAT` env var support: a classic PAT with `public_repo` scope, used only for the `gh pr create` step against `microsoft/winget-pkgs`
- Fork push still uses the App token (which has write access to `a2aproject/winget-pkgs`)
- If `WINGET_PAT` is unset, manifests are pushed to the fork but PR submission is skipped with a `::notice::` instead of failing

## Setup required
Add a `WINGET_PAT` repository secret: a classic PAT from any org member with `public_repo` scope.