### PR TITLE
fix(winget): handle 'PR already exists' error gracefully

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -145,9 +145,15 @@ jobs:
           Upstream release: $RELEASE_URL
           EOF
 
-          GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr create \
+          if ! GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr create \
             --repo microsoft/winget-pkgs \
             --base master \
             --head "$fork_owner:$branch" \
             --title "Add WinGet manifest for a2aproject.a2acli version $PACKAGE_VERSION" \
-            --body-file /tmp/winget-pr-body.md
+            --body-file /tmp/winget-pr-body.md 2>&1 | tee /tmp/gh-pr-create.log; then
+            if grep -q "already exists" /tmp/gh-pr-create.log; then
+              echo "PR already exists for $branch — branch updated in place"
+              exit 0
+            fi
+            exit 1
+          fi


### PR DESCRIPTION
The App token can't list PRs on microsoft/winget-pkgs, so the existing-PR check always misses open PRs. When `gh pr create` fails with 'already exists', the branch force-push has already updated the PR — treat it as success instead of failing the workflow.