### PR TITLE
fix(brew): install pre-built binary instead of building from source

### DIFF
--- a/Formula/a2acli.rb
+++ b/Formula/a2acli.rb
@@ -6,6 +6,7 @@ class A2acli < Formula
   homepage "https://github.com/a2aproject/a2a-rs"
   version "0.1.6"
   license "Apache-2.0"
+  depends_on :macos
 
   on_macos do
     on_arm do

--- a/Formula/a2acli.rb
+++ b/Formula/a2acli.rb
@@ -4,16 +4,23 @@
 class A2acli < Formula
   desc "Standalone A2A CLI client"
   homepage "https://github.com/a2aproject/a2a-rs"
-  url "https://github.com/a2aproject/a2a-rs/archive/refs/tags/a2a-cli-v0.1.6.tar.gz"
-  sha256 "8cce1316e3f16ff072cfccbdd676e7f378805752768a5b54c039a9b774fcbbdc"
+  version "0.1.6"
   license "Apache-2.0"
-  head "https://github.com/a2aproject/a2a-rs.git", branch: "main"
 
-  depends_on "cmake" => :build
-  depends_on "rust" => :build
+  on_macos do
+    on_arm do
+      url "https://github.com/a2aproject/a2a-rs/releases/download/a2a-cli-v#{version}/a2acli-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "15e6deba9687e6d967409e22b1adaa726012f30014a6ada637f102ec6534eaff"
+    end
+
+    on_intel do
+      url "https://github.com/a2aproject/a2a-rs/releases/download/a2a-cli-v#{version}/a2acli-v#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "7e6878bf6b2e4552a34f656fe511b459d3cc22a7765349d954e3ae87b88036ae"
+    end
+  end
 
   def install
-    system "cargo", "install", *std_cargo_args(path: "a2acli")
+    bin.install "a2acli"
   end
 
   test do

--- a/install.sh
+++ b/install.sh
@@ -124,7 +124,7 @@ resolve_release_tag() {
 
   local version
   version="$(fetch_text "$manifest_url" \
-    | grep -m1 '^version' \
+    | grep -m1 '^version[[:space:]]*=' \
     | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
   [[ -n "$version" ]] || die "failed to resolve the latest a2acli version from $manifest_url"
   printf '%s\n' "${RELEASE_PREFIX}${version}"

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@
 #   A2A_CLI_VERSION              Install a specific version such as 0.1.5,
 #                                v0.1.5, or a2a-cli-v0.1.5.
 #   A2A_CLI_INSTALL_DIR          Directory to place the a2acli binary.
-#   A2A_CLI_RELEASE_API_URL      Override the releases metadata API URL.
+#   A2A_CLI_CARGO_MANIFEST_URL   Override the Cargo.toml URL used to resolve the latest version.
 #   A2A_CLI_RELEASE_DOWNLOAD_BASE_URL  Override the release asset download base URL.
 
 set -euo pipefail
@@ -19,7 +19,7 @@ set -euo pipefail
 REPO_OWNER="a2aproject"
 REPO_NAME="a2a-rs"
 RELEASE_PREFIX="a2a-cli-v"
-DEFAULT_RELEASE_API_URL="https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases"
+DEFAULT_CARGO_MANIFEST_URL="https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/a2acli/Cargo.toml"
 DEFAULT_RELEASE_DOWNLOAD_BASE_URL="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/download"
 TARGET_X86_64="x86_64-unknown-linux-gnu"
 TARGET_ARM64="aarch64-unknown-linux-gnu"
@@ -35,7 +35,7 @@ Environment overrides:
   A2A_CLI_VERSION                    Install a specific version such as 0.1.5,
                                      v0.1.5, or a2a-cli-v0.1.5.
   A2A_CLI_INSTALL_DIR                Directory to place the a2acli binary.
-  A2A_CLI_RELEASE_API_URL            Override the releases metadata API URL.
+  A2A_CLI_CARGO_MANIFEST_URL         Override the Cargo.toml URL used to resolve the latest version.
   A2A_CLI_RELEASE_DOWNLOAD_BASE_URL  Override the release asset download base URL.
 EOF
 }
@@ -82,12 +82,12 @@ fetch_text() {
   local url="$1"
 
   if have_cmd curl; then
-    curl -fsSL --retry 3 -H 'Accept: application/vnd.github+json' "$url"
+    curl -fsSL --retry 3 "$url"
     return
   fi
 
   if have_cmd wget; then
-    wget -qO- --header='Accept: application/vnd.github+json' "$url"
+    wget -qO- "$url"
     return
   fi
 
@@ -119,21 +119,15 @@ resolve_release_tag() {
     return
   fi
 
-  local api_url
-  api_url="${A2A_CLI_RELEASE_API_URL:-$DEFAULT_RELEASE_API_URL}"
+  local manifest_url
+  manifest_url="${A2A_CLI_CARGO_MANIFEST_URL:-$DEFAULT_CARGO_MANIFEST_URL}"
 
-  local response
-  response="$(fetch_text "$api_url")"
-
-  # Releases are returned newest-first; find the first a2a-cli-v* tag
-  local tag
-  tag="$(printf '%s\n' "$response" \
-    | grep -oE '"tag_name"[[:space:]]*:[[:space:]]*"a2a-cli-v[^"]*"' \
-    | head -1 \
-    | grep -oE '"a2a-cli-v[^"]*"' \
-    | tr -d '"' || true)"
-  [[ -n "$tag" ]] || die "failed to resolve the latest a2acli release tag from $api_url"
-  printf '%s\n' "$tag"
+  local version
+  version="$(fetch_text "$manifest_url" \
+    | grep -m1 '^version' \
+    | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
+  [[ -n "$version" ]] || die "failed to resolve the latest a2acli version from $manifest_url"
+  printf '%s\n' "${RELEASE_PREFIX}${version}"
 }
 
 resolve_target() {

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -69,9 +69,10 @@ def fetch_text(url: str) -> str:
 def fetch_release_sha256(tag: str, version: str, target: str) -> str:
     checksum_url = f"{RELEASE_BASE_URL}/{tag}/a2acli-v{version}-{target}.tar.gz.sha256"
     text = fetch_text(checksum_url)
-    sha = text.split()[0].lower()
-    if not sha:
+    parts = text.split()
+    if not parts:
         raise SystemExit(f"empty checksum from {checksum_url}")
+    sha = parts[0].lower()
     return sha
 
 
@@ -106,6 +107,7 @@ def render_formula(tag: str) -> str:
         f'  homepage "{ruby_string(homepage)}"\n'
         f'  version "{version}"\n'
         f'  license "{ruby_string(license_id)}"\n'
+        f"  depends_on :macos\n"
         f"\n"
         f"  on_macos do\n"
         f"    on_arm do\n"

--- a/scripts/render_homebrew_formula.py
+++ b/scripts/render_homebrew_formula.py
@@ -5,10 +5,8 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 from pathlib import Path
 import re
-import textwrap
 import tomllib
 import urllib.error
 import urllib.request
@@ -19,13 +17,9 @@ WORKSPACE_MANIFEST = ROOT / "Cargo.toml"
 CLI_MANIFEST = ROOT / "a2acli" / "Cargo.toml"
 DEFAULT_OUTPUT = ROOT / "Formula" / "a2acli.rb"
 TAG_PATTERN = re.compile(r"^a2a-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
-FORMULA_HEADER = textwrap.dedent(
-    """\
-    # Copyright AGNTCY Contributors (https://github.com/agntcy)
-    # SPDX-License-Identifier: Apache-2.0
-
-    """
-)
+MACOS_ARM64_TARGET = "aarch64-apple-darwin"
+MACOS_X86_64_TARGET = "x86_64-apple-darwin"
+RELEASE_BASE_URL = "https://github.com/a2aproject/a2a-rs/releases/download"
 
 
 def parse_args() -> argparse.Namespace:
@@ -62,20 +56,23 @@ def resolve_workspace_value(package: dict, workspace_package: dict, key: str) ->
     return value
 
 
-def fetch_sha256(url: str) -> str:
+def fetch_text(url: str) -> str:
     request = urllib.request.Request(url, headers={"User-Agent": "a2aproject-release-automation"})
-    digest = hashlib.sha256()
     try:
         with urllib.request.urlopen(request, timeout=60) as response:
-            while True:
-                chunk = response.read(1024 * 1024)
-                if not chunk:
-                    break
-                digest.update(chunk)
+            return response.read().decode("utf-8")
     except urllib.error.URLError as error:
         reason = f"HTTP {error.code}" if isinstance(error, urllib.error.HTTPError) else error.reason
         raise SystemExit(f"failed to fetch {url}: {reason}") from error
-    return digest.hexdigest()
+
+
+def fetch_release_sha256(tag: str, version: str, target: str) -> str:
+    checksum_url = f"{RELEASE_BASE_URL}/{tag}/a2acli-v{version}-{target}.tar.gz.sha256"
+    text = fetch_text(checksum_url)
+    sha = text.split()[0].lower()
+    if not sha:
+        raise SystemExit(f"empty checksum from {checksum_url}")
+    return sha
 
 
 def ruby_string(value: str) -> str:
@@ -86,6 +83,7 @@ def render_formula(tag: str) -> str:
     match = TAG_PATTERN.match(tag)
     if not match:
         raise SystemExit(f"expected a2a-cli-v<version> tag, got: {tag}")
+    version = match.group("version")
 
     workspace = load_toml(WORKSPACE_MANIFEST)
     cli_manifest = load_toml(CLI_MANIFEST)
@@ -95,35 +93,41 @@ def render_formula(tag: str) -> str:
     description = package["description"]
     homepage = resolve_workspace_value(package, workspace_package, "repository")
     license_id = resolve_workspace_value(package, workspace_package, "license")
-    source_url = f"{homepage}/archive/refs/tags/{tag}.tar.gz"
-    source_sha256 = fetch_sha256(source_url)
-    git_url = homepage if homepage.endswith(".git") else f"{homepage}.git"
 
-    formula_body = textwrap.dedent(
-        f"""\
-        class A2acli < Formula
-          desc \"{ruby_string(description)}\"
-          homepage \"{ruby_string(homepage)}\"
-          url \"{ruby_string(source_url)}\"
-          sha256 \"{source_sha256}\"
-          license \"{ruby_string(license_id)}\"
-          head \"{ruby_string(git_url)}\", branch: \"main\"
+    arm64_sha256 = fetch_release_sha256(tag, version, MACOS_ARM64_TARGET)
+    x86_64_sha256 = fetch_release_sha256(tag, version, MACOS_X86_64_TARGET)
 
-          depends_on \"cmake\" => :build
-          depends_on \"rust\" => :build
-
-          def install
-            system \"cargo\", \"install\", *std_cargo_args(path: \"a2acli\")
-          end
-
-          test do
-            assert_match \"a2acli\", shell_output(\"#{{bin}}/a2acli --help\")
-          end
-        end
-        """
+    return (
+        f"# Copyright AGNTCY Contributors (https://github.com/agntcy)\n"
+        f"# SPDX-License-Identifier: Apache-2.0\n"
+        f"\n"
+        f'class A2acli < Formula\n'
+        f'  desc "{ruby_string(description)}"\n'
+        f'  homepage "{ruby_string(homepage)}"\n'
+        f'  version "{version}"\n'
+        f'  license "{ruby_string(license_id)}"\n'
+        f"\n"
+        f"  on_macos do\n"
+        f"    on_arm do\n"
+        f'      url "{RELEASE_BASE_URL}/a2a-cli-v#{{version}}/a2acli-v#{{version}}-{MACOS_ARM64_TARGET}.tar.gz"\n'
+        f'      sha256 "{arm64_sha256}"\n'
+        f"    end\n"
+        f"\n"
+        f"    on_intel do\n"
+        f'      url "{RELEASE_BASE_URL}/a2a-cli-v#{{version}}/a2acli-v#{{version}}-{MACOS_X86_64_TARGET}.tar.gz"\n'
+        f'      sha256 "{x86_64_sha256}"\n'
+        f"    end\n"
+        f"  end\n"
+        f"\n"
+        f"  def install\n"
+        f'    bin.install "a2acli"\n'
+        f"  end\n"
+        f"\n"
+        f"  test do\n"
+        f'    assert_match "a2acli", shell_output("#{{bin}}/a2acli --help")\n'
+        f"  end\n"
+        f"end\n"
     )
-
-    return f"{FORMULA_HEADER}{formula_body}"
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary

- Replace source build (`cargo install`) with pre-built macOS binaries from the GitHub release assets
- Remove `cmake` and `rust` build dependencies from the Homebrew formula
- Update `render_homebrew_formula.py` to fetch per-arch SHA256s from release `.sha256` files
- Resolve latest version from raw `a2acli/Cargo.toml` in `install.sh` instead of the GitHub API (avoids rate limiting)

## Test plan

- [ ] `brew upgrade a2acli` installs without compiling
- [ ] `a2acli --version` reports correct version
- [ ] Run `render_homebrew_formula.py --tag a2a-cli-v<next>` on the next release and verify formula output