### PR TITLE
feat(slimrpc)!: migrate a2a-slimrpc onto native agntcy-slim-rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca6bb123f78d7f2c14140638ef07e2e8a88b239b3852efe1c7f83d03662fc6"
+checksum = "421c3302596f9298c8fc57182c84381b17f0e20681e7930c6211e4d39c26e68c"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d510bcf30a9743b811564d4b168a95ab3789c705b42f6287b63e5e5a7a9bb34"
+checksum = "2f9acd36127fe01f3175795bd46e0f0ced9ced4a6dfaf56a2bdc3e08c4c09fd9"
 dependencies = [
  "agntcy-slim-version",
  "aws-lc-rs",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c3302596f9298c8fc57182c84381b17f0e20681e7930c6211e4d39c26e68c"
+checksum = "44c230d21b7ff14b039ce0eef5fd9b5912d819fe6c0b21c653348c69ac400c13"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "376742003fd178caa5edfa49ccef99637a8bc846434f3a840ffc321d5a859f0e"
+checksum = "94300285f29418c4860d1965bf4bb24ad091e9fc64ea0ceec015a75be7f03abe"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1856d5fdfab3d1b52bbb7ffa17cb1a9a8bbb4724b7a33aa6f0fb0d3cd0787364"
+checksum = "fb174b04bc4c03c1a36b9febedac279a051399a52e090bd96236a162cb277be2"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d0fa62ca7a3dec226ba50c180c5e54833f7dd90b37d277d93dcd4527ce6d6c"
+checksum = "432e81905ee835155199bc8c3b82378a9fa7e98b49a890df539efae43277c115"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea63211f04d62a4cce088b6fd5c5acde87a85a609f0c1b66795b16989934bbd2"
+checksum = "df2245bddf34d2adb4b88ed3ae7f519234e8814cb77172befcbb361afd5442b1"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9937de9f9266f88d143e8a4d985a638200a666406099fe31285fbad5f9f27c94"
+checksum = "3436a6202933b26de20a965c3d53d18b5201f7ef589a7023cee8697fc7f946d5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef0bea7e6ea3864ef13ea079f1450db82103af9a9164b2158903ff9b5ba270d"
+checksum = "289a5c0fcc673c1c7892a943900a4e2b12b57fc21584e0c655282d28e5b5db8f"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820d53cabd700c1f0175fbe376dd07c251ea2bcef6cc1b3e1032d4fbbea45eab"
+checksum = "eabfc55cd2966cb3ef605ca1dae3246cdf94ff7aa3b58ddcdc18403930ae5609"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "908bf5a234c12ae8fcc14dd88805714afd4222dddbfacdd72ae1bf0c05f13587"
+checksum = "bfa135cef8d8920ceb361b1c27f23636a6b3226fa3173726931339ddd18a4eae"
 
 [[package]]
 name = "aho-corasick"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 name = "a2a-lf"
 version = "0.3.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "serde",
  "serde_json",
@@ -124,13 +124,17 @@ dependencies = [
 
 [[package]]
 name = "a2a-slimrpc"
-version = "0.1.13"
+version = "0.2.0"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
  "a2a-pb",
  "a2a-server-lf",
- "agntcy-slim-bindings",
+ "agntcy-slim-auth",
+ "agntcy-slim-config",
+ "agntcy-slim-datapath",
+ "agntcy-slim-rpc",
+ "agntcy-slim-service",
  "async-trait",
  "futures",
  "prost",
@@ -139,49 +143,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "agntcy-slim"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c480ffbd888328bcdf6284315814ebd5dc825ea5b8f20b70d121cde4dea83b24"
-dependencies = [
- "agntcy-slim-config",
- "agntcy-slim-service",
- "agntcy-slim-signal",
- "agntcy-slim-tracing",
- "agntcy-slim-version",
- "anyhow",
- "clap",
- "duration-string",
- "indexmap",
- "jemallocator",
- "lazy_static",
- "num_cpus",
- "serde",
- "serde_yaml",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "agntcy-slim-auth"
-version = "0.6.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "701ac4d13268dd459b748312f4388976eb70f9f37842572079773fc099875f87"
+checksum = "8d510bcf30a9743b811564d4b168a95ab3789c705b42f6287b63e5e5a7a9bb34"
 dependencies = [
  "agntcy-slim-version",
- "async-trait",
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
+ "cfg-if",
  "display-error-chain",
+ "ed25519-dalek",
  "futures",
+ "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "headers",
+ "hmac",
  "http",
- "jsonwebtoken 10.3.0",
+ "itoa",
+ "jsonwebtoken",
  "mls-rs-core",
  "mls-rs-crypto-awslc",
  "notify",
  "oauth2",
+ "p256",
  "parking_lot",
  "pin-project",
  "prost-types",
@@ -190,6 +175,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "sha2",
  "spiffe",
  "thiserror 2.0.18",
  "tokio",
@@ -198,62 +184,38 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "trait-variant",
  "url",
+ "web-time",
  "wiremock",
 ]
 
 [[package]]
-name = "agntcy-slim-bindings"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05962640ce809aa9b5255e0b50a8462ce0b15cbaa1c88e84d410cb9be9b6e64"
-dependencies = [
- "agntcy-slim",
- "agntcy-slim-auth",
- "agntcy-slim-config",
- "agntcy-slim-controller",
- "agntcy-slim-datapath",
- "agntcy-slim-service",
- "agntcy-slim-session",
- "agntcy-slim-signal",
- "agntcy-slim-tracing",
- "agntcy-slim-version",
- "async-stream",
- "async-trait",
- "display-error-chain",
- "drain",
- "futures",
- "futures-timer",
- "parking_lot",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tracing",
- "uniffi",
- "uuid",
-]
-
-[[package]]
 name = "agntcy-slim-config"
-version = "0.8.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976d3c441f4c971f05b5a3d1342b261fd163a679e5270022d79bfc8daaba1092"
+checksum = "9eca6bb123f78d7f2c14140638ef07e2e8a88b239b3852efe1c7f83d03662fc6"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
  "async-trait",
- "base64",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
  "display-error-chain",
  "drain",
  "duration-string",
+ "fastwebsockets",
  "futures",
+ "gloo-net",
  "http",
+ "http-body-util",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "lazy_static",
  "parking_lot",
+ "percent-encoding",
  "prost",
  "protoc-bin-vendored",
  "regex",
@@ -264,9 +226,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha1",
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -284,25 +248,25 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.4.12"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b1b2588d29b6f466d30b4443bde88767da1c5f356b8fcea27de43a0e8589d28"
+checksum = "376742003fd178caa5edfa49ccef99637a8bc846434f3a840ffc321d5a859f0e"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
  "agntcy-slim-datapath",
+ "agntcy-slim-proto",
  "agntcy-slim-session",
  "agntcy-slim-signal",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
  "display-error-chain",
  "drain",
+ "futures",
  "h2",
  "parking_lot",
  "prost",
  "prost-types",
- "protoc-bin-vendored",
- "rand 0.9.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -311,70 +275,125 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.12.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc2e22492b7a9466799a8f2ab5a5bfa3a3c0a9303d50e2470f02af526b48e09"
+checksum = "1856d5fdfab3d1b52bbb7ffa17cb1a9a8bbb4724b7a33aa6f0fb0d3cd0787364"
 dependencies = [
  "agntcy-slim-config",
+ "agntcy-slim-proto",
  "agntcy-slim-tracing",
  "agntcy-slim-version",
- "bincode",
- "bit-vec",
+ "arc-swap",
+ "aws-lc-rs",
+ "cfg-if",
  "display-error-chain",
  "drain",
+ "fastwebsockets",
+ "futures",
+ "getrandom 0.3.4",
+ "gloo-net",
  "h2",
- "opentelemetry",
+ "hkdf",
+ "hmac",
+ "http",
  "parking_lot",
  "prost",
- "protoc-bin-vendored",
- "rand 0.9.4",
  "semver",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tokio_with_wasm",
+ "tonic",
+ "tonic-prost",
+ "tracing",
+ "trait-variant",
+ "twox-hash",
+ "uuid",
+ "wasm-bindgen-futures",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "agntcy-slim-mls"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d0fa62ca7a3dec226ba50c180c5e54833f7dd90b37d277d93dcd4527ce6d6c"
+dependencies = [
+ "agntcy-slim-auth",
+ "agntcy-slim-version",
+ "async-trait",
+ "base64 0.22.1",
+ "getrandom 0.3.4",
+ "hex",
+ "maybe-async",
+ "mls-rs",
+ "mls-rs-core",
+ "mls-rs-crypto-awslc",
+ "mls-rs-crypto-webcrypto",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "agntcy-slim-proto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea63211f04d62a4cce088b6fd5c5acde87a85a609f0c1b66795b16989934bbd2"
+dependencies = [
+ "agntcy-slim-config",
+ "agntcy-slim-version",
+ "prost",
+ "prost-types",
+ "protoc-bin-vendored",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
- "tracing",
- "tracing-opentelemetry",
  "twox-hash",
  "uuid",
 ]
 
 [[package]]
-name = "agntcy-slim-mls"
-version = "0.1.14"
+name = "agntcy-slim-rpc"
+version = "2.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031842cbb051156563ad1481ff9a27c3144fe82fa1c9b53e9dbec0ae7f59d89c"
+checksum = "ee2f6d7daa77f8828d35b0733a92675022b92ab3c1fb2737b31eed2ec10a06ac"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
- "agntcy-slim-version",
- "base64",
- "hex",
- "mls-rs",
- "mls-rs-core",
- "mls-rs-crypto-awslc",
- "serde_json",
+ "agntcy-slim-service",
+ "agntcy-slim-session",
+ "async-stream",
+ "async-trait",
+ "display-error-chain",
+ "drain",
+ "futures",
+ "futures-timer",
+ "parking_lot",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.8.11"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864c66723835c6a2e2a96c10b345923a2ad35b463493f72380e45650bdd6de21"
+checksum = "a60eeefbe422463f5bf4fb5762f2e635ec92e57fe9550609fb006edeeb272557"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -392,37 +411,48 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "twox-hash",
+ "uuid",
 ]
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.1.11"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "211ddffc2a3f0d7b64aa2e666c16ec0b7d78a88f37c9e9253f290f3fc3c3b246"
+checksum = "9937de9f9266f88d143e8a4d985a638200a666406099fe31285fbad5f9f27c94"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
  "agntcy-slim-mls",
  "agntcy-slim-version",
  "async-trait",
+ "base64 0.22.1",
  "display-error-chain",
  "futures",
  "futures-timer",
+ "lru",
+ "maybe-async",
  "parking_lot",
+ "prost",
  "rand 0.9.4",
  "serde",
+ "serde_json",
+ "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tonic",
  "tracing",
+ "trait-variant",
+ "twox-hash",
 ]
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c358daa90b0fa0698cc1ecf7c0d8d79790fac412ae89f97a0e81062b610302b5"
+checksum = "7ef0bea7e6ea3864ef13ea079f1450db82103af9a9164b2158903ff9b5ba270d"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -431,12 +461,14 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f243e04744cb62641c1c9c58824ccf3297a00231e870926ae7d824ac8d41439c"
+checksum = "820d53cabd700c1f0175fbe376dd07c251ea2bcef6cc1b3e1032d4fbbea45eab"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
+ "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -448,14 +480,15 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "tracing-web",
  "uuid",
 ]
 
 [[package]]
 name = "agntcy-slim-version"
-version = "1.3.0"
+version = "2.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c3fafc0c5fb9e6ed9a3cb60995cad01ad17e97e826ef5bfca2be780a874fb9"
+checksum = "908bf5a234c12ae8fcc14dd88805714afd4222dddbfacdd72ae1bf0c05f13587"
 
 [[package]]
 name = "aho-corasick"
@@ -465,6 +498,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -538,48 +577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "askama"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4744ed2eef2645831b441d8f5459689ade2ab27c854488fbab1fbe94fce1a7"
-dependencies = [
- "askama_derive",
- "itoa",
- "percent-encoding",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d661e0f57be36a5c14c48f78d09011e67e0cb618f269cca9f2fd8d15b68c46ac"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "memchr",
- "proc-macro2",
- "quote",
- "rustc-hash",
- "serde",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "askama_parser"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf315ce6524c857bb129ff794935cf6d42c82a6cff60526fe2a63593de4d0d4f"
-dependencies = [
- "memchr",
- "serde",
- "serde_derive",
- "winnow",
 ]
 
 [[package]]
@@ -703,11 +700,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0e6249c249b8916c98ebae7bc06216c8dcab3002f32872b4abe642d17063b1"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+ "regex",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "untrusted 0.7.1",
  "zeroize",
@@ -719,6 +732,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -798,7 +812,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "either",
- "fs-err 3.3.0",
+ "fs-err",
  "http",
  "http-body",
  "hyper",
@@ -812,51 +826,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "basic-toml"
-version = "0.1.10"
+name = "base64ct"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "serde",
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
 ]
-
-[[package]]
-name = "beef"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -903,38 +914,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,6 +923,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -959,6 +947,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +969,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1044,6 +1054,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1090,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1110,6 +1135,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,6 +1154,32 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1193,7 +1256,19 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "der_derive",
+ "zeroize",
 ]
 
 [[package]]
@@ -1208,6 +1283,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1232,7 +1318,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid 0.9.6",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1285,10 +1373,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1348,6 +1491,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fastwebsockets"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305d3ba574508e27190906d11707dad683e0494e6b85eae9b044cb2734a5e422"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project",
+ "rand 0.8.5",
+ "sha1",
+ "simdutf8",
+ "thiserror 1.0.69",
+ "tokio",
+ "utf-8",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,15 +1578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs-err"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1531,6 +1707,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1569,6 +1746,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1580,14 +1758,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "goblin"
-version = "0.8.2"
+name = "gloo-net"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
 dependencies = [
- "log",
- "plain",
- "scroll",
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "gloo-utils",
+ "http",
+ "js-sys",
+ "pin-project",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1615,7 +1823,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1623,6 +1831,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -1630,7 +1843,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -1667,6 +1880,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1749,7 +1980,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1787,7 +2017,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2001,6 +2231,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2013,26 +2252,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "jni"
@@ -2107,27 +2326,12 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -2176,6 +2380,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,37 +2417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "logos"
-version = "0.15.1"
+name = "lru"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff472f899b4ec2d99161c51f60ff7075eeb3097069a36050d8037a6325eb8154"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
 dependencies = [
- "logos-derive",
-]
-
-[[package]]
-name = "logos-codegen"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192a3a2b90b0c05b27a0b2c43eecdb7c415e29243acc3f89cc8247a5b693045c"
-dependencies = [
- "beef",
- "fnv",
- "lazy_static",
- "proc-macro2",
- "quote",
- "regex-syntax",
- "rustc_version",
- "syn",
-]
-
-[[package]]
-name = "logos-derive"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "605d9697bcd5ef3a42d38efc51541aa3d6a4a25f7ab6d1ed0da5ac632a26b470"
-dependencies = [
- "logos-codegen",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -2275,28 +2464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "cfg-if",
- "miette-derive",
- "unicode-width",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,7 +2499,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "hex",
- "itertools",
+ "itertools 0.14.0",
  "maybe-async",
  "mls-rs-codec",
  "mls-rs-core",
@@ -2355,7 +2522,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bd834f164dc06c1fed805540ae307a460b7ed7c2769a35a376f1de577a0dc1"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "mls-rs-codec-derive",
  "thiserror 2.0.18",
  "wasm-bindgen",
@@ -2431,6 +2598,29 @@ dependencies = [
  "async-trait",
  "maybe-async",
  "mls-rs-core",
+ "zeroize",
+]
+
+[[package]]
+name = "mls-rs-crypto-webcrypto"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292a8e8a85689c029a6f6b0c7a7eef0f390a044ef176b80d0442b38948c66e35"
+dependencies = [
+ "async-trait",
+ "const-oid 0.10.2",
+ "der 0.8.1",
+ "js-sys",
+ "maybe-async",
+ "mls-rs-core",
+ "mls-rs-crypto-hpke",
+ "mls-rs-crypto-traits",
+ "serde",
+ "serde-wasm-bindgen",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "zeroize",
 ]
 
@@ -2566,7 +2756,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http",
@@ -2739,6 +2929,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,7 +2969,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8edd1efdd8ab23ba9cb9ace3d9987a72663d5d7c9f74fa00b51d6213645cf6c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -2778,7 +2980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ed4d5c6ae95e08ac768883c8401cf0e8deb4e6e1d6a4e1fd3d2ec4f0ec63200"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "prost",
  "prost-types",
 ]
@@ -2804,7 +3006,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2857,7 +3059,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
+ "der 0.7.10",
  "spki",
 ]
 
@@ -2866,12 +3068,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2953,6 +3149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,7 +3183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -2999,22 +3204,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-reflect"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
-dependencies = [
- "logos",
- "miette",
- "prost",
- "prost-types",
 ]
 
 [[package]]
@@ -3089,33 +3282,6 @@ name = "protoc-bin-vendored-win32"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
-
-[[package]]
-name = "protox"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f25a07a73c6717f0b9bbbd685918f5df9815f7efba450b83d9c9dea41f0e3a1"
-dependencies = [
- "bytes",
- "miette",
- "prost",
- "prost-reflect",
- "prost-types",
- "protox-parse",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "protox-parse"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "072eee358134396a4643dff81cfff1c255c9fbd3fb296be14bdb6a26f9156366"
-dependencies = [
- "logos",
- "miette",
- "prost-types",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "pulldown-cmark"
@@ -3236,6 +3402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3274,6 +3451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3303,7 +3486,7 @@ dependencies = [
  "pem",
  "rustls-pki-types",
  "time",
- "x509-parser 0.18.1",
+ "x509-parser",
  "yasna",
 ]
 
@@ -3371,7 +3554,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -3389,7 +3572,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -3405,7 +3587,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3414,7 +3595,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3453,6 +3634,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -3515,7 +3706,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3654,23 +3844,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scroll"
-version = "0.12.0"
+name = "sec1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3701,10 +3885,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -3714,6 +3894,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3803,7 +3994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3814,7 +4005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3849,6 +4040,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -3881,12 +4073,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3897,12 +4083,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
@@ -3916,33 +4096,30 @@ dependencies = [
 
 [[package]]
 name = "spiffe"
-version = "0.6.7"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f805aae79ba04a1f0b2e5e06de0bbb2e7851ea3588d03fdf8f25075a0111603"
+checksum = "6ce89d478a0709d93311d0ff6981902893a912cc573b00dcb40f0d15856d4950"
 dependencies = [
- "anyhow",
+ "arc-swap",
+ "base64ct",
+ "fastrand",
+ "futures",
  "hyper-util",
- "jsonwebtoken 9.3.1",
- "log",
+ "jsonwebtoken",
  "pkcs8",
  "prost",
- "prost-build",
  "prost-types",
- "protox",
  "serde",
  "serde_json",
- "simple_asn1",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tokio-stream",
  "tokio-util",
  "tonic",
  "tonic-prost",
- "tonic-prost-build",
  "tower",
  "url",
- "x509-parser 0.17.0",
+ "x509-parser",
  "zeroize",
 ]
 
@@ -3961,7 +4138,8 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
- "der",
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -3969,12 +4147,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -4058,15 +4230,6 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
-name = "textwrap"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
-dependencies = [
- "smawk",
-]
 
 [[package]]
 name = "thiserror"
@@ -4175,9 +4338,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4213,12 +4376,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-retry"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
- "pin-project",
- "rand 0.8.5",
+ "pin-project-lite",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -4257,12 +4420,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.5.11"
+name = "tokio_with_wasm"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "ef3ce6a8f5b5190dfe4851db6c969e8360a262759e16a0b75dfc43af19d97a86"
 dependencies = [
- "serde",
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d8aa1d26c1550eef93cfb2dafadc145b3220432dae8d156b5ba485880594ffe"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4273,7 +4451,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -4377,7 +4555,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
@@ -4503,6 +4681,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-web"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e6a141feebd51f8d91ebfd785af50fca223c570b86852166caa3b141defe7c"
+dependencies = [
+ "js-sys",
+ "tracing-core",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4536,149 +4738,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "uniffi"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3291800a6b06569f7d3e15bdb6dc235e0f0c8bd3eb07177f430057feb076415f"
-dependencies = [
- "anyhow",
- "camino",
- "cargo_metadata",
- "clap",
- "uniffi_bindgen",
- "uniffi_build",
- "uniffi_core",
- "uniffi_macros",
- "uniffi_pipeline",
-]
-
-[[package]]
-name = "uniffi_bindgen"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04b99fa7796eaaa7b87976a0dbdd1178dc1ee702ea00aca2642003aef9b669e"
-dependencies = [
- "anyhow",
- "askama",
- "camino",
- "cargo_metadata",
- "fs-err 2.11.0",
- "glob",
- "goblin",
- "heck",
- "indexmap",
- "once_cell",
- "serde",
- "tempfile",
- "textwrap",
- "toml",
- "uniffi_internal_macros",
- "uniffi_meta",
- "uniffi_pipeline",
- "uniffi_udl",
-]
-
-[[package]]
-name = "uniffi_build"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025a05cba02ee22b6624ac3d257e59c7395319ea8fe1aae33a7cdb4e2a3016cc"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen",
-]
-
-[[package]]
-name = "uniffi_core"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38a9a27529ccff732f8efddb831b65b1e07f7dea3fd4cacd4a35a8c4b253b98"
-dependencies = [
- "anyhow",
- "bytes",
- "once_cell",
- "static_assertions",
-]
-
-[[package]]
-name = "uniffi_internal_macros"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09acd2ce09c777dd65ee97c251d33c8a972afc04873f1e3b21eb3492ade16933"
-dependencies = [
- "anyhow",
- "indexmap",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "uniffi_macros"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5596f178c4f7aafa1a501c4e0b96236a96bc2ef92bdb453d83e609dad0040152"
-dependencies = [
- "camino",
- "fs-err 2.11.0",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "syn",
- "toml",
- "uniffi_meta",
-]
-
-[[package]]
-name = "uniffi_meta"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beadc1f460eb2e209263c49c4f5b19e9a02e00a3b2b393f78ad10d766346ecff"
-dependencies = [
- "anyhow",
- "siphasher",
- "uniffi_internal_macros",
- "uniffi_pipeline",
-]
-
-[[package]]
-name = "uniffi_pipeline"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd76b3ac8a2d964ca9fce7df21c755afb4c77b054a85ad7a029ad179cc5abb8a"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "tempfile",
- "uniffi_internal_macros",
-]
-
-[[package]]
-name = "uniffi_udl"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319cf905911d70d5b97ce0f46f101619a22e9a189c8c46d797a9955e9233716"
-dependencies = [
- "anyhow",
- "textwrap",
- "uniffi_meta",
- "weedle2",
-]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4699,12 +4762,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4716,6 +4773,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4757,12 +4820,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "wait-timeout"
@@ -4945,24 +5002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "weedle2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -5201,22 +5240,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wiremock"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64",
+ "base64 0.22.1",
  "deadpool",
  "futures",
  "http",
@@ -5327,20 +5357,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "x509-parser"
-version = "0.17.0"
+name = "x25519-dalek"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror 2.0.18",
- "time",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ a2a-client = { package = "a2a-client-lf", path = "a2a-client", version = "0.2.0"
 a2a-server = { package = "a2a-server-lf", path = "a2a-server", version = "0.4.0", default-features = false }
 a2a-pb = { package = "a2a-pb", path = "a2a-pb", version = "0.1.8" }
 a2a-grpc = { package = "a2a-grpc", path = "a2a-grpc", version = "0.3.0", default-features = false }
-a2a-slimrpc = { package = "a2a-slimrpc", path = "a2a-slimrpc", version = "0.1.13" }
+a2a-slimrpc = { package = "a2a-slimrpc", path = "a2a-slimrpc", version = "0.2.0" }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
@@ -71,7 +71,13 @@ prost = "0.14"
 prost-types = "0.14"
 pbjson-build = "0.9"
 protoc-bin-vendored = "3"
-slim_bindings = { package = "agntcy-slim-bindings", version = "1.3.0" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.3" }
+slim_config = { package = "agntcy-slim-config", version = "0.12.1" }
+slim_service = { package = "agntcy-slim-service", version = "0.11.1", features = [
+    "session",
+] }
+slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.2" }
+slim_auth = { package = "agntcy-slim-auth", version = "0.12.0" }
 
 # Utilities
 rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }

--- a/a2a-pb/src/lib.rs
+++ b/a2a-pb/src/lib.rs
@@ -7,6 +7,12 @@ pub mod proto {
 
 /// ProtoJSON-capable generated protobuf types for the A2A v1 protocol.
 pub mod protojson {
+    // Generated serde code emits `write!(f, "...", &FIELDS)`, which newer
+    // clippy flags as a useless borrow. Suppress it for the generated module.
+    // `unknown_lints` keeps this compiling on clippy versions predating the lint.
+    #![allow(unknown_lints)]
+    #![allow(clippy::useless_borrows_in_formatting)]
+
     include!(concat!(env!("OUT_DIR"), "/lf.a2a.v1.rs"));
     include!(concat!(env!("OUT_DIR"), "/lf.a2a.v1.serde.rs"));
 }

--- a/a2a-slimrpc/Cargo.toml
+++ b/a2a-slimrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2a-slimrpc"
-version = "0.1.13"
+version = "0.2.0"
 description = "A2A v1 SLIMRPC protocol binding for client and server"
 readme = "README.md"
 edition.workspace = true
@@ -20,7 +20,11 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 futures = { workspace = true }
 async-trait = { workspace = true }
-slim_bindings = { workspace = true }
+slim_rpc = { workspace = true }
+slim_service = { workspace = true }
+slim_datapath = { workspace = true }
+slim_auth = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+slim_config = { workspace = true }

--- a/a2a-slimrpc/src/client.rs
+++ b/a2a-slimrpc/src/client.rs
@@ -8,6 +8,13 @@ use a2a_client::transport::{ServiceParams, Transport, TransportFactory};
 use a2a_pb::pbconv;
 use async_trait::async_trait;
 use futures::{StreamExt, stream::BoxStream};
+use slim_datapath::api::ProtoName;
+
+/// Native SLIM application type backing the RPC channel.
+pub type SlimApp = slim_service::app::App<
+    slim_auth::auth_provider::AuthProvider,
+    slim_auth::auth_provider::AuthVerifier,
+>;
 
 use crate::common::{
     A2A_SLIMRPC_SERVICE, METHOD_CANCEL_TASK, METHOD_CREATE_PUSH_CONFIG, METHOD_DELETE_PUSH_CONFIG,
@@ -20,25 +27,25 @@ use crate::errors::rpc_error_to_a2a_error;
 
 /// SLIMRPC transport for A2A clients.
 pub struct SlimRpcTransport {
-    channel: slim_bindings::Channel,
+    channel: slim_rpc::Channel,
 }
 
 impl SlimRpcTransport {
-    pub fn new(app: Arc<slim_bindings::App>, remote: Arc<slim_bindings::Name>) -> Self {
+    pub fn new(app: Arc<SlimApp>, remote: Arc<ProtoName>) -> Self {
         Self::new_with_connection(app, remote, None)
     }
 
     pub fn new_with_connection(
-        app: Arc<slim_bindings::App>,
-        remote: Arc<slim_bindings::Name>,
+        app: Arc<SlimApp>,
+        remote: Arc<ProtoName>,
         connection_id: Option<u64>,
     ) -> Self {
         Self {
-            channel: slim_bindings::Channel::new_with_connection(app, remote, connection_id),
+            channel: slim_rpc::Channel::new_with_connection(app, remote, connection_id),
         }
     }
 
-    pub fn from_channel(channel: slim_bindings::Channel) -> Self {
+    pub fn from_channel(channel: slim_rpc::Channel) -> Self {
         Self { channel }
     }
 
@@ -93,13 +100,13 @@ impl SlimRpcTransport {
 
         let stream = futures::stream::unfold(reader, move |reader| async move {
             match reader.next_async().await {
-                slim_bindings::StreamMessage::Data(data) => {
+                slim_rpc::StreamMessage::Data(data) => {
                     Some((decode_proto_response::<Res>(data, response_name), reader))
                 }
-                slim_bindings::StreamMessage::Error(error) => {
+                slim_rpc::StreamMessage::Error(error) => {
                     Some((Err(rpc_error_to_a2a_error(&error)), reader))
                 }
-                slim_bindings::StreamMessage::End => None,
+                slim_rpc::StreamMessage::End => None,
             }
         });
 
@@ -310,19 +317,19 @@ impl Transport for SlimRpcTransport {
 
 #[derive(Clone)]
 pub struct SlimRpcTransportFactory {
-    app: Arc<slim_bindings::App>,
+    app: Arc<SlimApp>,
     connection_id: Option<u64>,
 }
 
 impl SlimRpcTransportFactory {
-    pub fn new(app: Arc<slim_bindings::App>) -> Self {
+    pub fn new(app: Arc<SlimApp>) -> Self {
         Self {
             app,
             connection_id: None,
         }
     }
 
-    pub fn new_with_connection(app: Arc<slim_bindings::App>, connection_id: Option<u64>) -> Self {
+    pub fn new_with_connection(app: Arc<SlimApp>, connection_id: Option<u64>) -> Self {
         Self { app, connection_id }
     }
 }
@@ -346,7 +353,7 @@ impl TransportFactory for SlimRpcTransportFactory {
 }
 
 /// Parse a SLIMRPC target from agent card interface data.
-pub fn parse_slimrpc_target(target: &str) -> Result<Arc<slim_bindings::Name>, A2AError> {
+pub fn parse_slimrpc_target(target: &str) -> Result<Arc<ProtoName>, A2AError> {
     let normalized = target
         .trim()
         .strip_prefix("slimrpc://")
@@ -354,11 +361,21 @@ pub fn parse_slimrpc_target(target: &str) -> Result<Arc<slim_bindings::Name>, A2
         .unwrap_or(target.trim())
         .trim_start_matches('/');
 
-    let name = slim_bindings::Name::from_string(normalized.to_string()).map_err(|error| {
-        A2AError::invalid_params(format!("invalid SLIMRPC target '{target}': {error}"))
-    })?;
+    let components: Vec<&str> = normalized.split('/').collect();
+    let [org, namespace, agent] = components.as_slice() else {
+        return Err(A2AError::invalid_params(format!(
+            "invalid SLIMRPC target '{target}': expected 'org/namespace/agent'"
+        )));
+    };
+    if org.is_empty() || namespace.is_empty() || agent.is_empty() {
+        return Err(A2AError::invalid_params(format!(
+            "invalid SLIMRPC target '{target}': components must be non-empty"
+        )));
+    }
 
-    Ok(Arc::new(name))
+    Ok(Arc::new(ProtoName::from_strings([
+        *org, *namespace, *agent,
+    ])))
 }
 
 #[cfg(test)]
@@ -368,22 +385,22 @@ mod tests {
     #[test]
     fn test_parse_slimrpc_target_plain_name() {
         let name = parse_slimrpc_target("org/namespace/agent").unwrap();
-        assert_eq!(name.components(), vec!["org", "namespace", "agent"]);
+        assert_eq!(name.str_components(), ("org", "namespace", "agent"));
     }
 
     #[test]
     fn test_parse_slimrpc_target_scheme() {
         let name = parse_slimrpc_target("slimrpc://org/namespace/agent").unwrap();
-        assert_eq!(name.components(), vec!["org", "namespace", "agent"]);
+        assert_eq!(name.str_components(), ("org", "namespace", "agent"));
     }
 
     #[test]
     fn test_parse_slimrpc_target_slim_scheme_and_leading_slash() {
         let name = parse_slimrpc_target("slim://org/namespace/agent").unwrap();
-        assert_eq!(name.components(), vec!["org", "namespace", "agent"]);
+        assert_eq!(name.str_components(), ("org", "namespace", "agent"));
 
         let name = parse_slimrpc_target("/org/namespace/agent").unwrap();
-        assert_eq!(name.components(), vec!["org", "namespace", "agent"]);
+        assert_eq!(name.str_components(), ("org", "namespace", "agent"));
     }
 
     #[test]

--- a/a2a-slimrpc/src/common.rs
+++ b/a2a-slimrpc/src/common.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use a2a::A2AError;
 use prost::Message;
-use slim_bindings::{Context, DEADLINE_KEY, RpcError, STATUS_CODE_KEY};
+use slim_rpc::{Context, DEADLINE_KEY, RpcError, STATUS_CODE_KEY};
 
 pub type ServiceParamsMap = HashMap<String, Vec<String>>;
 
@@ -148,7 +148,7 @@ mod tests {
     #[test]
     fn test_decode_proto_request_invalid_payload() {
         let error = decode_proto_request::<a2a_pb::proto::Task>(vec![0xff], "Task").unwrap_err();
-        assert_eq!(error.code(), slim_bindings::RpcCode::InvalidArgument);
+        assert_eq!(error.code(), slim_rpc::RpcCode::InvalidArgument);
         assert!(error.message().contains("invalid Task payload"));
     }
 }

--- a/a2a-slimrpc/src/errors.rs
+++ b/a2a-slimrpc/src/errors.rs
@@ -3,36 +3,34 @@
 use a2a::A2AError;
 
 /// Convert an A2A error to a SLIMRPC status.
-pub fn a2a_error_to_rpc_error(err: &A2AError) -> slim_bindings::RpcError {
+pub fn a2a_error_to_rpc_error(err: &A2AError) -> slim_rpc::RpcError {
     use a2a::error_code;
 
     match err.code {
-        error_code::TASK_NOT_FOUND => slim_bindings::RpcError::not_found(err.message.clone()),
+        error_code::TASK_NOT_FOUND => slim_rpc::RpcError::not_found(err.message.clone()),
         error_code::TASK_NOT_CANCELABLE
         | error_code::EXTENSION_SUPPORT_REQUIRED
         | error_code::VERSION_NOT_SUPPORTED
         | error_code::PUSH_NOTIFICATION_NOT_SUPPORTED
         | error_code::UNSUPPORTED_OPERATION
         | error_code::EXTENDED_CARD_NOT_CONFIGURED => {
-            slim_bindings::RpcError::failed_precondition(err.message.clone())
+            slim_rpc::RpcError::failed_precondition(err.message.clone())
         }
         error_code::CONTENT_TYPE_NOT_SUPPORTED
         | error_code::PARSE_ERROR
         | error_code::INVALID_REQUEST
-        | error_code::INVALID_PARAMS => {
-            slim_bindings::RpcError::invalid_argument(err.message.clone())
-        }
+        | error_code::INVALID_PARAMS => slim_rpc::RpcError::invalid_argument(err.message.clone()),
         error_code::INVALID_AGENT_RESPONSE | error_code::INTERNAL_ERROR => {
-            slim_bindings::RpcError::internal(err.message.clone())
+            slim_rpc::RpcError::internal(err.message.clone())
         }
-        _ => slim_bindings::RpcError::unknown(err.message.clone()),
+        _ => slim_rpc::RpcError::unknown(err.message.clone()),
     }
 }
 
 /// Convert a SLIMRPC status to an A2A error.
-pub fn rpc_error_to_a2a_error(error: &slim_bindings::RpcError) -> A2AError {
+pub fn rpc_error_to_a2a_error(error: &slim_rpc::RpcError) -> A2AError {
     use a2a::error_code;
-    use slim_bindings::RpcCode;
+    use slim_rpc::RpcCode;
 
     let code = match error.code() {
         RpcCode::NotFound => error_code::TASK_NOT_FOUND,
@@ -53,7 +51,7 @@ pub fn rpc_error_to_a2a_error(error: &slim_bindings::RpcError) -> A2AError {
 mod tests {
     use super::*;
     use a2a::error_code;
-    use slim_bindings::RpcCode;
+    use slim_rpc::RpcCode;
 
     #[test]
     fn test_a2a_error_to_rpc_error_mapping() {
@@ -94,7 +92,7 @@ mod tests {
         ];
 
         for (rpc_code, expected) in cases {
-            let error = slim_bindings::RpcError::new(rpc_code, "test");
+            let error = slim_rpc::RpcError::new(rpc_code, "test");
             assert_eq!(rpc_error_to_a2a_error(&error).code, expected);
         }
     }
@@ -135,7 +133,7 @@ mod tests {
         ];
 
         for (rpc_code, expected) in cases {
-            let error = slim_bindings::RpcError::new(rpc_code, "test");
+            let error = slim_rpc::RpcError::new(rpc_code, "test");
             assert_eq!(rpc_error_to_a2a_error(&error).code, expected);
         }
     }

--- a/a2a-slimrpc/src/lib.rs
+++ b/a2a-slimrpc/src/lib.rs
@@ -5,5 +5,5 @@ mod common;
 pub mod errors;
 pub mod server;
 
-pub use client::{SlimRpcTransport, SlimRpcTransportFactory, parse_slimrpc_target};
+pub use client::{SlimApp, SlimRpcTransport, SlimRpcTransportFactory, parse_slimrpc_target};
 pub use server::SlimRpcHandler;

--- a/a2a-slimrpc/src/server.rs
+++ b/a2a-slimrpc/src/server.rs
@@ -21,7 +21,7 @@ use crate::errors::a2a_error_to_rpc_error;
 
 type HandlerFuture<T> = Pin<Box<dyn Future<Output = Result<T, A2AError>> + Send>>;
 
-/// Registers A2A request handling methods on a `slim_bindings::Server`.
+/// Registers A2A request handling methods on a `slim_rpc::Server`.
 pub struct SlimRpcHandler<H: RequestHandler> {
     handler: Arc<H>,
 }
@@ -31,7 +31,7 @@ impl<H: RequestHandler> SlimRpcHandler<H> {
         Self { handler }
     }
 
-    pub fn register(&self, server: &slim_bindings::Server) {
+    pub fn register(&self, server: &slim_rpc::Server) {
         register_unary_unary::<H, proto::SendMessageRequest, _, _, _, _>(
             server,
             self.handler.clone(),
@@ -158,7 +158,7 @@ impl<H: RequestHandler> SlimRpcHandler<H> {
 }
 
 fn register_unary_unary<H, ReqProto, ReqNative, ResNative, DecodeReq, EncodeRes>(
-    server: &slim_bindings::Server,
+    server: &slim_rpc::Server,
     handler: Arc<H>,
     method_name: &'static str,
     request_name: &'static str,
@@ -183,7 +183,7 @@ fn register_unary_unary<H, ReqProto, ReqNative, ResNative, DecodeReq, EncodeRes>
     server.register_unary_unary_internal(
         A2A_SLIMRPC_SERVICE,
         method_name,
-        move |request: Vec<u8>, context: slim_bindings::Context| {
+        move |request: Vec<u8>, context: slim_rpc::Context| {
             let handler = handler.clone();
             let decode_req = decode_req.clone();
             let call = call.clone();
@@ -202,14 +202,14 @@ fn register_unary_unary<H, ReqProto, ReqNative, ResNative, DecodeReq, EncodeRes>
     );
 }
 
-fn register_unary_stream_send_message<H>(server: &slim_bindings::Server, handler: Arc<H>)
+fn register_unary_stream_send_message<H>(server: &slim_rpc::Server, handler: Arc<H>)
 where
     H: RequestHandler,
 {
     server.register_unary_stream_internal(
         A2A_SLIMRPC_SERVICE,
         METHOD_SEND_STREAMING_MESSAGE,
-        move |request: Vec<u8>, context: slim_bindings::Context| {
+        move |request: Vec<u8>, context: slim_rpc::Context| {
             let handler = handler.clone();
 
             async move {
@@ -230,14 +230,14 @@ where
     );
 }
 
-fn register_unary_stream_subscribe_to_task<H>(server: &slim_bindings::Server, handler: Arc<H>)
+fn register_unary_stream_subscribe_to_task<H>(server: &slim_rpc::Server, handler: Arc<H>)
 where
     H: RequestHandler,
 {
     server.register_unary_stream_internal(
         A2A_SLIMRPC_SERVICE,
         METHOD_SUBSCRIBE_TO_TASK,
-        move |request: Vec<u8>, context: slim_bindings::Context| {
+        move |request: Vec<u8>, context: slim_rpc::Context| {
             let handler = handler.clone();
 
             async move {
@@ -260,7 +260,7 @@ where
 
 fn map_stream_response(
     response: Result<StreamResponse, A2AError>,
-) -> Result<Vec<u8>, slim_bindings::RpcError> {
+) -> Result<Vec<u8>, slim_rpc::RpcError> {
     response
         .map(|response| encode_proto_message(&pbconv::to_proto_stream_response(&response)))
         .map_err(|error| a2a_error_to_rpc_error(&error))

--- a/a2a-slimrpc/tests/e2e.rs
+++ b/a2a-slimrpc/tests/e2e.rs
@@ -8,15 +8,18 @@ use a2a::*;
 use a2a_client::Transport;
 use a2a_client::transport::{ServiceParams, TransportFactory};
 use a2a_server::RequestHandler;
+use a2a_slimrpc::SlimApp;
 use a2a_slimrpc::{SlimRpcHandler, SlimRpcTransport, SlimRpcTransportFactory};
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures::stream::{self, BoxStream};
 use prost::Message as _;
-use slim_bindings::{
-    App, Channel, Direction, IdentityProviderConfig, IdentityVerifierConfig, Name, RpcError,
-    Server, initialize_with_defaults,
-};
+use slim_auth::auth_provider::{AuthProvider, AuthVerifier};
+use slim_auth::shared_secret::SharedSecret;
+use slim_config::component::id::{ID, Kind};
+use slim_datapath::api::ProtoName as Name;
+use slim_rpc::{Channel, RpcError, Server};
+use slim_service::service::Service;
 
 const A2A_SERVICE_NAME: &str = "lf.a2a.v1.A2AService";
 const GET_TASK_METHOD: &str = "GetTask";
@@ -91,51 +94,46 @@ fn send_message_request(task_id: &str) -> SendMessageRequest {
     }
 }
 
-fn provider_config(id: &str) -> IdentityProviderConfig {
-    IdentityProviderConfig::SharedSecret {
-        id: id.to_string(),
-        data: SHARED_SECRET.to_string(),
-    }
-}
-
-fn verifier_config(id: &str) -> IdentityVerifierConfig {
-    IdentityVerifierConfig::SharedSecret {
-        id: id.to_string(),
-        data: SHARED_SECRET.to_string(),
-    }
+/// Build a shared-secret auth provider/verifier pair for the given identity id.
+fn auth(id: &str) -> (AuthProvider, AuthVerifier) {
+    let secret = SharedSecret::new(id, SHARED_SECRET).unwrap();
+    (
+        AuthProvider::shared_secret(secret.clone()),
+        AuthVerifier::shared_secret(secret),
+    )
 }
 
 struct TestEnv {
     test_name: String,
+    service: Arc<Service>,
     server: Arc<Server>,
-    _server_app: Arc<App>,
+    _server_app: Arc<SlimApp>,
     server_name: Arc<Name>,
 }
 
 impl TestEnv {
     async fn new(test_name: &str) -> Self {
-        initialize_with_defaults();
+        let id = ID::new_with_name(Kind::new("slim").unwrap(), test_name).unwrap();
+        let service = Arc::new(Service::new(id));
 
-        let server_name = Arc::new(Name::new(
-            "org".to_string(),
-            "test".to_string(),
-            test_name.to_string(),
+        let server_name = Name::from_strings(["org", "test", test_name]);
+        let (provider, verifier) = auth("test-provider");
+        let (server_app, server_notifications) = service
+            .create_app(&server_name, provider, verifier)
+            .unwrap();
+        let server_app = Arc::new(server_app);
+        let server = Arc::new(Server::new_internal(
+            server_app.clone(),
+            server_app.app_name().clone(),
+            server_notifications,
         ));
-        let server_app = App::new_with_direction_async(
-            server_name.clone(),
-            provider_config("test-provider"),
-            verifier_config("test-verifier"),
-            Direction::Bidirectional,
-        )
-        .await
-        .unwrap();
-        let server = Arc::new(Server::new(&server_app, server_app.name().clone()));
 
         Self {
             test_name: test_name.to_string(),
+            service,
             server,
             _server_app: server_app,
-            server_name,
+            server_name: Arc::new(server_name),
         }
     }
 
@@ -152,21 +150,15 @@ impl TestEnv {
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
-    async fn new_client_app(&self, suffix: &str) -> Arc<App> {
-        let name = Arc::new(Name::new(
+    async fn new_client_app(&self, suffix: &str) -> Arc<SlimApp> {
+        let name = Name::from_strings([
             "org".to_string(),
             "test".to_string(),
             format!("{}-{suffix}", self.test_name),
-        ));
-
-        App::new_with_direction_async(
-            name,
-            provider_config("test-provider-client"),
-            verifier_config("test-verifier-client"),
-            Direction::Bidirectional,
-        )
-        .await
-        .unwrap()
+        ]);
+        let (provider, verifier) = auth("test-provider-client");
+        let (app, _) = self.service.create_app(&name, provider, verifier).unwrap();
+        Arc::new(app)
     }
 
     async fn transport(&self, suffix: &str) -> SlimRpcTransport {


### PR DESCRIPTION
Repoints `a2a-slimrpc` off the UniFFI shim (`agntcy-slim-bindings` 1.3.x) onto the native **`agntcy-slim-rpc` 2.0.0-alpha.3**, removing the entire UniFFI stack from the A2A dependency chain.

- **Deps:** drop `slim_bindings`; add `slim_rpc` + native `slim_service` (App), `slim_datapath` (`ProtoName`), `slim_auth` (auth provider/verifier).
- **RPC types** (`Channel`/`Server`/`Context`/`RpcError`/`RpcCode`/`StreamMessage`) now from `slim_rpc`.
- **App/Name → native:** `SlimApp = slim_service::app::App<AuthProvider, AuthVerifier>`, `slim_datapath::api::ProtoName`. `parse_slimrpc_target` splits `org/namespace/agent` → `ProtoName::from_strings`.
- **e2e tests** build apps via `Service::create_app` instead of the FFI constructor.

All unit + e2e tests pass; `clippy -D warnings` + `fmt` clean.

**BREAKING:** `SlimRpcTransport`/`Factory` now take native `App`/`Name` instead of the FFI types → **`a2a-slimrpc` 0.2.0**. Unblocks the SHADI SLIM-v2 migration (step D).