### PR TITLE
fix(slimrpc): update to slim native crates with the #1869 MLS fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9acd36127fe01f3175795bd46e0f0ced9ced4a6dfaf56a2bdc3e08c4c09fd9"
+checksum = "41b98ca02a9e0d5239129100897e5e94c1aceb12ff38d5736e69623523c6821e"
 dependencies = [
  "agntcy-slim-version",
  "aws-lc-rs",
@@ -192,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c230d21b7ff14b039ce0eef5fd9b5912d819fe6c0b21c653348c69ac400c13"
+checksum = "d2da3f6ff7aa525e6122cd94256758ffb2173d2f3826f94c2a715c1bdc2576a5"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300285f29418c4860d1965bf4bb24ad091e9fc64ea0ceec015a75be7f03abe"
+checksum = "27977052e5632be864cc1a7c79b3363477e55cac17c5ce1ae5628ae862e69616"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb174b04bc4c03c1a36b9febedac279a051399a52e090bd96236a162cb277be2"
+checksum = "e49518aa0031c476830224bc133f6af354f5241ee0a1acca398d96d20b95499e"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "432e81905ee835155199bc8c3b82378a9fa7e98b49a890df539efae43277c115"
+checksum = "182a3ee8b786612d5077d0d6c499a741932db874785e98d7d33e443cef459a81"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2245bddf34d2adb4b88ed3ae7f519234e8814cb77172befcbb361afd5442b1"
+checksum = "2792f4ee0962ac6658ee6cfe3af76d5d0af87f14303ff3bf0b99b5420f182dcc"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2f6d7daa77f8828d35b0733a92675022b92ab3c1fb2737b31eed2ec10a06ac"
+checksum = "8cea5d59109d3996016323aef1a05e4fb49393dfdfe4515177a63c5bf2925e9a"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.1"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a60eeefbe422463f5bf4fb5762f2e635ec92e57fe9550609fb006edeeb272557"
+checksum = "8ba9f9d0ff0342914cebb2886fe6c052086015b07fafc38e84fd1f583b54052f"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3436a6202933b26de20a965c3d53d18b5201f7ef589a7023cee8697fc7f946d5"
+checksum = "123b71d61965341381948e5ac4a989f421a1f9b06ee879cd97b6326b79ac2c45"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289a5c0fcc673c1c7892a943900a4e2b12b57fc21584e0c655282d28e5b5db8f"
+checksum = "b1291fda899bb54b565fdfa447c2880fc9c1d48037948ccea3083c394e6e582f"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabfc55cd2966cb3ef605ca1dae3246cdf94ff7aa3b58ddcdc18403930ae5609"
+checksum = "29966bdaa2e170d2653c56233b717af02d777554128497cb6f3b30ea7b46beda"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -486,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.4"
+version = "2.0.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa135cef8d8920ceb361b1c27f23636a6b3226fa3173726931339ddd18a4eae"
+checksum = "424fbe0dd7171dc6bf184fdc3a55df805058e9b69e5c63711d8bd484ef11125d"
 
 [[package]]
 name = "aho-corasick"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,13 +71,13 @@ prost = "0.14"
 prost-types = "0.14"
 pbjson-build = "0.9"
 protoc-bin-vendored = "3"
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.3" }
-slim_config = { package = "agntcy-slim-config", version = "0.12.1" }
-slim_service = { package = "agntcy-slim-service", version = "0.11.1", features = [
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.5" }
+slim_config = { package = "agntcy-slim-config", version = "0.12.3" }
+slim_service = { package = "agntcy-slim-service", version = "0.11.4", features = [
     "session",
 ] }
-slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.2" }
-slim_auth = { package = "agntcy-slim-auth", version = "0.12.0" }
+slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.5" }
+slim_auth = { package = "agntcy-slim-auth", version = "0.13.0" }
 
 # Utilities
 rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }


### PR DESCRIPTION
Bumps the slim v2 native deps to the release including [agntcy/slim#1869](https://github.com/agntcy/slim/pull/1869) (mid-handshake MLS signing-key rotation fix — resolves the intermittent `add participant … message send retries exhausted` session flake):

- `agntcy-slim-auth` 0.12 → **0.13**
- `agntcy-slim-rpc` alpha.3 → **alpha.5**
- `agntcy-slim-config` 0.12.1 → **0.12.3**
- `agntcy-slim-service` 0.11.1 → **0.11.4**
- `agntcy-slim-datapath` 0.16.2 → **0.16.5**

No API changes; a2a-slimrpc lib + e2e pass. Unblocks downstream (SHADI): `auth 0.13` and `slim-bindings 2.0.0-alpha.7` must resolve to the same auth version, so a2a-slimrpc had to move first.