### PR TITLE
fix(slimrpc): migrate a2a-slimrpc onto slim 0.14 native crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "a2a-slimrpc"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "a2a-client-lf",
  "a2a-lf",
@@ -135,6 +135,7 @@ dependencies = [
  "agntcy-slim-datapath",
  "agntcy-slim-rpc",
  "agntcy-slim-service",
+ "async-stream",
  "async-trait",
  "futures",
  "prost",
@@ -144,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-auth"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b98ca02a9e0d5239129100897e5e94c1aceb12ff38d5736e69623523c6821e"
+checksum = "654c8837097d60e5b743d78e0cbd9f6652c30c5eea1f9d2220ca0c0f03eaa5b2"
 dependencies = [
  "agntcy-slim-version",
  "aws-lc-rs",
@@ -192,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-config"
-version = "0.12.4"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2da3f6ff7aa525e6122cd94256758ffb2173d2f3826f94c2a715c1bdc2576a5"
+checksum = "d9d88023cb3c5531fe7d649a312038986830c5ea112e73e93ef464091e8f28a1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -248,9 +249,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-controller"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27977052e5632be864cc1a7c79b3363477e55cac17c5ce1ae5628ae862e69616"
+checksum = "9e6e6650f780c9c825df1bbe0b5dc4ffe8700da15a541a07c9c74e21a066ba8b"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -281,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-datapath"
-version = "0.16.5"
+version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e49518aa0031c476830224bc133f6af354f5241ee0a1acca398d96d20b95499e"
+checksum = "31ddc1f599b42926bf968c156b19ffb9424be8aa92899eff3d95e63b65fe8684"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-proto",
@@ -325,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-mls"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "182a3ee8b786612d5077d0d6c499a741932db874785e98d7d33e443cef459a81"
+checksum = "6df5215c5cd95bf4638eb6f60f2943602d30486a12e5d7bc7e9b3f7e7970cb30"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-version",
@@ -347,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-proto"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2792f4ee0962ac6658ee6cfe3af76d5d0af87f14303ff3bf0b99b5420f182dcc"
+checksum = "f30847ae9f69167f24e549368ef6dfe537068866215e20e0b8faea1eb35d07d7"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -367,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-rpc"
-version = "2.0.0-alpha.5"
+version = "2.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cea5d59109d3996016323aef1a05e4fb49393dfdfe4515177a63c5bf2925e9a"
+checksum = "8e9fea60e5dd2ca3094dc0c64946cbcc1bfd0fd81d067fba650aea4e31cae75d"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -391,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-service"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9f9d0ff0342914cebb2886fe6c052086015b07fafc38e84fd1f583b54052f"
+checksum = "07f69c52ac896b7843749153304946a7e3ab92a73507fd6e28fb3cf8c09fc416"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-config",
@@ -417,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-session"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "123b71d61965341381948e5ac4a989f421a1f9b06ee879cd97b6326b79ac2c45"
+checksum = "e419f8c615ed19d92ad0d12ef5a8b70b47becf926ee688fa869c3c09e8dd86e1"
 dependencies = [
  "agntcy-slim-auth",
  "agntcy-slim-datapath",
@@ -450,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-signal"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1291fda899bb54b565fdfa447c2880fc9c1d48037948ccea3083c394e6e582f"
+checksum = "966ba5a71aa51239bc0394dd01404c4a675ef41a7283cde057c1bf31ac0a6246"
 dependencies = [
  "agntcy-slim-version",
  "tokio",
@@ -461,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-tracing"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29966bdaa2e170d2653c56233b717af02d777554128497cb6f3b30ea7b46beda"
+checksum = "c3874c68c12f1b117bc763a58f0e273448ea1ca9b0e1ef9c02f3901545bb0370"
 dependencies = [
  "agntcy-slim-config",
  "agntcy-slim-version",
@@ -486,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "agntcy-slim-version"
-version = "2.0.0-alpha.5"
+version = "2.0.0-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424fbe0dd7171dc6bf184fdc3a55df805058e9b69e5c63711d8bd484ef11125d"
+checksum = "e1b9b83586d2291268127d8c44e430f18da32df2e5e99affffce3ee295b4c8dc"
 
 [[package]]
 name = "aho-corasick"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,12 +72,12 @@ prost = "0.14"
 prost-types = "0.14"
 pbjson-build = "0.9"
 protoc-bin-vendored = "3"
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.6" }
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.7" }
 slim_config = { package = "agntcy-slim-config", version = "0.12.6" }
-slim_service = { package = "agntcy-slim-service", version = "0.11.5", features = [
+slim_service = { package = "agntcy-slim-service", version = "0.11.6", features = [
     "session",
 ] }
-slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.6" }
+slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.7" }
 slim_auth = { package = "agntcy-slim-auth", version = "0.14.0" }
 
 # Utilities

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ pbjson-types = "0.9"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 futures = "0.3"
+async-stream = "0.3"
 async-trait = "0.1"
 pin-project-lite = "0.2"
 
@@ -71,13 +72,13 @@ prost = "0.14"
 prost-types = "0.14"
 pbjson-build = "0.9"
 protoc-bin-vendored = "3"
-slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.5" }
-slim_config = { package = "agntcy-slim-config", version = "0.12.3" }
-slim_service = { package = "agntcy-slim-service", version = "0.11.4", features = [
+slim_rpc = { package = "agntcy-slim-rpc", version = "2.0.0-alpha.6" }
+slim_config = { package = "agntcy-slim-config", version = "0.12.6" }
+slim_service = { package = "agntcy-slim-service", version = "0.11.5", features = [
     "session",
 ] }
-slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.5" }
-slim_auth = { package = "agntcy-slim-auth", version = "0.13.0" }
+slim_datapath = { package = "agntcy-slim-datapath", version = "0.16.6" }
+slim_auth = { package = "agntcy-slim-auth", version = "0.14.0" }
 
 # Utilities
 rcgen = { version = "0.14", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }

--- a/a2a-slimrpc/Cargo.toml
+++ b/a2a-slimrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2a-slimrpc"
-version = "0.2.1"
+version = "0.2.2"
 description = "A2A v1 SLIMRPC protocol binding for client and server"
 readme = "README.md"
 edition.workspace = true
@@ -19,6 +19,7 @@ a2a-pb = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 futures = { workspace = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 slim_rpc = { workspace = true }
 slim_service = { workspace = true }

--- a/a2a-slimrpc/src/client.rs
+++ b/a2a-slimrpc/src/client.rs
@@ -62,9 +62,9 @@ impl SlimRpcTransport {
     {
         let response = self
             .channel
-            .call_unary_async(
-                A2A_SLIMRPC_SERVICE.to_string(),
-                method_name.to_string(),
+            .unary::<Vec<u8>, Vec<u8>>(
+                A2A_SLIMRPC_SERVICE,
+                method_name,
                 encode_proto_message(request),
                 None,
                 service_params_to_metadata_opt(params),
@@ -86,29 +86,31 @@ impl SlimRpcTransport {
         Req: prost::Message,
         Res: prost::Message + Default + Send + 'static,
     {
-        let reader = self
-            .channel
-            .call_unary_stream_async(
-                A2A_SLIMRPC_SERVICE.to_string(),
-                method_name.to_string(),
-                encode_proto_message(request),
-                None,
-                service_params_to_metadata_opt(params),
-            )
-            .await
-            .map_err(|error| rpc_error_to_a2a_error(&error))?;
+        // `Channel::unary_stream` borrows `&self` (its `impl Stream` return captures the
+        // channel's lifetime), but the `Transport` trait requires a `'static` stream.
+        // Own a channel clone inside an `async_stream` generator so the driven inner
+        // stream lives as long as the returned stream. Errors are delivered as stream
+        // items, so there is no fallible setup step to await up front.
+        let channel = self.channel.clone();
+        let payload = encode_proto_message(request);
+        let metadata = service_params_to_metadata_opt(params);
 
-        let stream = futures::stream::unfold(reader, move |reader| async move {
-            match reader.next_async().await {
-                slim_rpc::StreamMessage::Data(data) => {
-                    Some((decode_proto_response::<Res>(data, response_name), reader))
-                }
-                slim_rpc::StreamMessage::Error(error) => {
-                    Some((Err(rpc_error_to_a2a_error(&error)), reader))
-                }
-                slim_rpc::StreamMessage::End => None,
+        let stream = async_stream::stream! {
+            let inner = channel.unary_stream::<Vec<u8>, Vec<u8>>(
+                A2A_SLIMRPC_SERVICE,
+                method_name,
+                payload,
+                None,
+                metadata,
+            );
+            futures::pin_mut!(inner);
+            while let Some(item) = inner.next().await {
+                yield match item {
+                    Ok(data) => decode_proto_response::<Res>(data, response_name),
+                    Err(error) => Err(rpc_error_to_a2a_error(&error)),
+                };
             }
-        });
+        };
 
         Ok(Box::pin(stream))
     }
@@ -279,11 +281,11 @@ impl Transport for SlimRpcTransport {
         req: &DeleteTaskPushNotificationConfigRequest,
     ) -> Result<(), A2AError> {
         let request = pbconv::to_proto_delete_task_push_notification_config_request(req);
-        let _response = self
+        let _response: Vec<u8> = self
             .channel
-            .call_unary_async(
-                A2A_SLIMRPC_SERVICE.to_string(),
-                METHOD_DELETE_PUSH_CONFIG.to_string(),
+            .unary(
+                A2A_SLIMRPC_SERVICE,
+                METHOD_DELETE_PUSH_CONFIG,
                 encode_proto_message(&request),
                 None,
                 service_params_to_metadata_opt(params),

--- a/a2a-slimrpc/src/server.rs
+++ b/a2a-slimrpc/src/server.rs
@@ -180,7 +180,7 @@ fn register_unary_unary<H, ReqProto, ReqNative, ResNative, DecodeReq, EncodeRes>
     let call = Arc::new(call);
     let encode_res = Arc::new(encode_res);
 
-    server.register_unary_unary_internal(
+    server.register_unary_unary(
         A2A_SLIMRPC_SERVICE,
         method_name,
         move |request: Vec<u8>, context: slim_rpc::Context| {
@@ -206,7 +206,7 @@ fn register_unary_stream_send_message<H>(server: &slim_rpc::Server, handler: Arc
 where
     H: RequestHandler,
 {
-    server.register_unary_stream_internal(
+    server.register_unary_stream(
         A2A_SLIMRPC_SERVICE,
         METHOD_SEND_STREAMING_MESSAGE,
         move |request: Vec<u8>, context: slim_rpc::Context| {
@@ -234,7 +234,7 @@ fn register_unary_stream_subscribe_to_task<H>(server: &slim_rpc::Server, handler
 where
     H: RequestHandler,
 {
-    server.register_unary_stream_internal(
+    server.register_unary_stream(
         A2A_SLIMRPC_SERVICE,
         METHOD_SUBSCRIBE_TO_TASK,
         move |request: Vec<u8>, context: slim_rpc::Context| {

--- a/a2a-slimrpc/tests/e2e.rs
+++ b/a2a-slimrpc/tests/e2e.rs
@@ -122,7 +122,7 @@ impl TestEnv {
             .create_app(&server_name, provider, verifier)
             .unwrap();
         let server_app = Arc::new(server_app);
-        let server = Arc::new(Server::new_internal(
+        let server = Arc::new(Server::new(
             server_app.clone(),
             server_app.app_name().clone(),
             server_notifications,
@@ -140,13 +140,13 @@ impl TestEnv {
     async fn start(&self) {
         let server = self.server.clone();
         tokio::spawn(async move {
-            let _ = server.serve_async().await;
+            let _ = server.serve().await;
         });
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 
     async fn shutdown(&self) {
-        self.server.shutdown_async().await;
+        self.server.shutdown().await;
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 
@@ -676,19 +676,19 @@ async fn slimrpc_transport_streaming_and_factory_paths() {
 async fn slimrpc_transport_reports_malformed_payloads() {
     let env = TestEnv::new("transport-malformed").await;
 
-    env.server.register_unary_unary_internal(
+    env.server.register_unary_unary(
         A2A_SERVICE_NAME,
         GET_TASK_METHOD,
         |_request: Vec<u8>, _context| async move { Ok(vec![0xff]) },
     );
-    env.server.register_unary_unary_internal(
+    env.server.register_unary_unary(
         A2A_SERVICE_NAME,
         SEND_MESSAGE_METHOD,
         |_request: Vec<u8>, _context| async move {
             Ok(a2a_pb::proto::SendMessageResponse::default().encode_to_vec())
         },
     );
-    env.server.register_unary_stream_internal(
+    env.server.register_unary_stream(
         A2A_SERVICE_NAME,
         SEND_STREAMING_MESSAGE_METHOD,
         |_request: Vec<u8>, _context| async move {


### PR DESCRIPTION
## Why

The slim 0.14 release carries a fix in `agntcy-slim-auth` for JWKS multi-key key selection (a token now verifies against the correct key in a multi-key allow-list instead of only the first — [agntcy/slim#1882](https://github.com/agntcy/slim/issues/1882) / [#1883](https://github.com/agntcy/slim/pull/1883)). Consuming it requires the whole slim family at 0.14, and `slim-rpc alpha.7` (the only rpc that depends on `auth ^0.14`) changed its public API — so this is a real migration, not just a version bump.

## Changes

Bump the workspace slim pins to the 0.14 family (auth 0.14.0, rpc 2.0.0-alpha.7, service 0.11.6, datapath 0.16.7, config 0.12.6) and migrate `a2a-slimrpc` to the new rpc API:

- **client**: `Channel::call_unary_async` / `call_unary_stream_async` → `Channel::unary` / `unary_stream` (now typed over `Encoder`/`Decoder`; used here with pass-through `Vec<u8>`). `unary_stream` returns a `&self`-bound stream, so it's driven inside an `async_stream` generator that owns a channel clone, keeping the `Transport` stream `'static`.
- **server**: `register_unary_unary_internal` / `register_unary_stream_internal` → the now-public `register_unary_unary` / `register_unary_stream`.
- **tests**: `Server::new_internal` / `serve_async` / `shutdown_async` → `Server::new` / `serve` / `shutdown`.

The public API of `a2a-slimrpc` (`SlimRpcTransport`, `SlimRpcHandler`) is unchanged. Bumps `a2a-slimrpc` to **0.2.2**; adds `async-stream`.

## Test

`cargo test -p a2a-slimrpc` — 15 unit + 3 e2e (live SLIM round-trip incl. streaming) pass; clippy `--all-targets` clean; fmt clean; workspace builds.