### PR TITLE
chore(ci): bump binary-build runners to latest images

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -31,13 +31,13 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - name: macOS arm64
-            runner: macos-latest
+            runner: macos-26
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-latest
+            runner: macos-26-intel
             target: x86_64-apple-darwin
           - name: Windows x86_64
-            runner: windows-latest
+            runner: windows-2025
             target: x86_64-pc-windows-msvc
 
     steps:

--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -87,13 +87,13 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - name: macOS arm64
-            runner: macos-latest
+            runner: macos-26
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-latest
+            runner: macos-26-intel
             target: x86_64-apple-darwin
           - name: Windows x86_64
-            runner: windows-latest
+            runner: windows-2025
             target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout

--- a/.github/workflows/release-upload-binaries.yml
+++ b/.github/workflows/release-upload-binaries.yml
@@ -28,13 +28,13 @@ jobs:
             runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
           - name: macOS arm64
-            runner: macos-latest
+            runner: macos-26
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            runner: macos-latest
+            runner: macos-26-intel
             target: x86_64-apple-darwin
           - name: Windows x86_64
-            runner: windows-latest
+            runner: windows-2025
             target: x86_64-pc-windows-msvc
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Bump macOS/Windows binary-build runners in `release-rust.yml`, `release-binaries.yml`, and `release-upload-binaries.yml` from the floating `macos-latest`/`windows-latest` labels to explicit, current pins: `macos-26`, `macos-26-intel`, `windows-2025`.
- Mirrors [agntcy/shadi#129](https://github.com/agntcy/shadi/pull/129).
- Also fixes a latent issue: both the "macOS arm64" and "macOS x86_64" matrix legs previously used the *same* `macos-latest` (arm64) runner, meaning the x86_64 binary was built via cross-compilation from an Apple Silicon host. Pinning `macos-26-intel` makes that leg build natively on an Intel runner.
- `ci.yml` is intentionally left on `macos-latest`/`windows-latest` since it's a simple build-and-test matrix (same rationale as shadi's PR, which also left `ci.yml` alone).

## Test plan
- [x] `actionlint` clean on all three modified workflow files
