### PR TITLE
ci(winget): validate the manifest on Windows before publishing

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -23,13 +23,17 @@ on:
         type: string
 
 jobs:
-  publish-winget-manifests:
+  render-winget-manifests:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      manifest_rel_dir: ${{ steps.render.outputs.manifest_rel_dir }}
+      package_identifier: ${{ steps.render.outputs.package_identifier }}
+      package_version: ${{ steps.render.outputs.package_version }}
+      release_url: ${{ steps.render.outputs.release_url }}
     env:
       RELEASE_TAG: ${{ inputs.release_tag }}
-      APP_AUTH_CONFIGURED: ${{ secrets.PROJECT_APP_ID != '' && secrets.PROJECT_APP_KEY != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -55,6 +59,73 @@ jobs:
           name: winget-manifests-${{ steps.render.outputs.package_version }}
           path: dist/winget/manifests
 
+  validate-winget-manifests:
+    needs: render-winget-manifests
+    runs-on: windows-2025
+    permissions:
+      contents: read
+    steps:
+      - name: Download rendered manifests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: winget-manifests-${{ needs.render-winget-manifests.outputs.package_version }}
+          path: manifests
+
+      - name: Show winget version
+        shell: pwsh
+        run: winget --version
+
+      - name: Validate manifests
+        shell: pwsh
+        env:
+          MANIFEST_REL_DIR: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+        run: |
+          $dir = Join-Path "manifests" ($env:MANIFEST_REL_DIR -replace '^manifests/', '')
+          Get-ChildItem $dir | ForEach-Object { Write-Host $_.Name }
+          winget validate --manifest $dir --ignore-warnings
+          if ($LASTEXITCODE -ne 0) { throw "winget validate failed with exit $LASTEXITCODE" }
+
+      - name: Install from the manifest and run the command
+        shell: pwsh
+        env:
+          MANIFEST_REL_DIR: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+          CLI: a2acli
+        run: |
+          function Assert-LastExit($what) {
+            if ($LASTEXITCODE -ne 0) { throw "$what failed with exit $LASTEXITCODE" }
+          }
+
+          $dir = Join-Path "manifests" ($env:MANIFEST_REL_DIR -replace '^manifests/', '')
+
+          winget settings --enable LocalManifestFiles
+          Assert-LastExit "winget settings --enable LocalManifestFiles"
+
+          winget install --manifest $dir `
+            --accept-package-agreements --accept-source-agreements --disable-interactivity
+          Assert-LastExit "winget install"
+
+          # A runner carries libraries a clean machine does not, so the PATH is
+          # cut back to what WinGet and Windows provide before the smoke test.
+          $env:PATH = "$env:LOCALAPPDATA\Microsoft\WinGet\Links;$env:SystemRoot\System32;$env:SystemRoot"
+          & $env:CLI --help
+          Assert-LastExit "$env:CLI --help"
+          Write-Host "OK - installed via winget and the binary runs"
+
+  publish-winget-manifests:
+    needs: [render-winget-manifests, validate-winget-manifests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      APP_AUTH_CONFIGURED: ${{ secrets.PROJECT_APP_ID != '' && secrets.PROJECT_APP_KEY != '' }}
+    steps:
+      - name: Download rendered manifests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: winget-manifests-${{ needs.render-winget-manifests.outputs.package_version }}
+          path: dist/winget/manifests
+
       - name: Authenticate with GitHub App Bot
         if: env.APP_AUTH_CONFIGURED == 'true'
         id: app-token
@@ -78,11 +149,11 @@ jobs:
           FORK_OWNER: ${{ github.repository_owner }}
           GIT_AUTHOR_NAME: ${{ steps.app-token.outputs.app-slug }}[bot]
           GIT_AUTHOR_EMAIL: ${{ steps.app-user.outputs.user_id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
-          MANIFEST_DIR: ${{ steps.render.outputs.manifest_dir }}
-          MANIFEST_REL_DIR: ${{ steps.render.outputs.manifest_rel_dir }}
-          PACKAGE_IDENTIFIER: ${{ steps.render.outputs.package_identifier }}
-          PACKAGE_VERSION: ${{ steps.render.outputs.package_version }}
-          RELEASE_URL: ${{ steps.render.outputs.release_url }}
+          MANIFEST_DIR: ${{ github.workspace }}/dist/winget/${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+          MANIFEST_REL_DIR: ${{ needs.render-winget-manifests.outputs.manifest_rel_dir }}
+          PACKAGE_IDENTIFIER: ${{ needs.render-winget-manifests.outputs.package_identifier }}
+          PACKAGE_VERSION: ${{ needs.render-winget-manifests.outputs.package_version }}
+          RELEASE_URL: ${{ needs.render-winget-manifests.outputs.release_url }}
         run: |
           if [ -z "$WINGET_PKGS_TOKEN" ]; then
             echo "::notice::PROJECT_APP_ID / PROJECT_APP_KEY are not configured; uploaded generated WinGet manifests as a workflow artifact only."

--- a/scripts/render_winget_manifests.py
+++ b/scripts/render_winget_manifests.py
@@ -28,6 +28,9 @@ PACKAGE_LOCALE = "en-US"
 PUBLISHER = "a2aproject"
 PACKAGE_NAME = "a2acli"
 MONIKER = "a2acli"
+# The MSVC-target binary imports VCRUNTIME140.dll, which a clean Windows
+# install does not carry, so WinGet validation cannot start it.
+VCREDIST_DEPENDENCY = "Microsoft.VCRedist.2015+.x64"
 WINDOWS_ARCHITECTURE = "x64"
 WINDOWS_TARGET = "x86_64-pc-windows-msvc"
 TAG_PATTERN = re.compile(r"^a2a-cli-v(?P<version>[0-9A-Za-z.+-]+)$")
@@ -257,6 +260,9 @@ def render_installer_manifest(release_assets: ReleaseAssets) -> str:
         f"Commands:\n"
         f"- {MONIKER}\n"
         f"ReleaseDate: {release_assets.release_date}\n"
+        f"Dependencies:\n"
+        f"  PackageDependencies:\n"
+        f"  - PackageIdentifier: {VCREDIST_DEPENDENCY}\n"
         f"Installers:\n"
         f"- Architecture: {WINDOWS_ARCHITECTURE}\n"
         f"  InstallerUrl: {release_assets.installer_url}\n"


### PR DESCRIPTION
Manifests went to microsoft/winget-pkgs without ever being installed. Brings the
pipeline in line with agntcy/shadi, where the same gap let a broken manifest
reach a reviewer.

Two changes:

- **Validation.** Render, validate and publish are now separate jobs. Publishing
  waits on a `windows-2025` runner that runs `winget validate`, installs from
  the manifest, and runs `a2acli --help` on a `PATH` cut back to the WinGet shim
  and the system directories — a runner carries libraries a clean machine does
  not, so an unreduced `PATH` passes regardless of what WinGet installed.
- **`Microsoft.VCRedist.2015+.x64` declared.** `a2acli.exe` imports
  `VCRUNTIME140.dll`, which a clean Windows install lacks. The manifest declared
  no dependencies, so validation could not have started the binary. This is what
  labelled agntcy/shadi's agentbridge manifest `Validation-Executable-Error`.

Untouched: the PR-creation step, so #121 still applies to the last mile.

- [x] manifest renders with the dependency; workflow YAML and publish script parse