### PR TITLE
ci(winget): push the manifests and hand the PR to a human

### DIFF
--- a/.github/workflows/winget-manifests.yml
+++ b/.github/workflows/winget-manifests.yml
@@ -143,7 +143,7 @@ jobs:
         run: |
           echo "user_id=$(gh api '/users/${{ steps.app-token.outputs.app-slug }}[bot]' --jq .id)" >> "$GITHUB_OUTPUT"
 
-      - name: Open or update winget-pkgs PR
+      - name: Push manifests to the winget-pkgs fork
         env:
           WINGET_PKGS_TOKEN: ${{ steps.app-token.outputs.token }}
           FORK_OWNER: ${{ github.repository_owner }}
@@ -186,6 +186,11 @@ jobs:
           git config user.email "$GIT_AUTHOR_EMAIL"
           git checkout -B "$branch" upstream/master
 
+          if [ ! -d "$MANIFEST_DIR" ]; then
+            echo "::error::rendered manifests are not at $MANIFEST_DIR"
+            exit 1
+          fi
+
           mkdir -p "$(dirname "$MANIFEST_REL_DIR")"
           rm -rf "$MANIFEST_REL_DIR"
           cp -R "$MANIFEST_DIR" "$(dirname "$MANIFEST_REL_DIR")/"
@@ -200,25 +205,24 @@ jobs:
           git commit -m "release: add WinGet manifest for a2acli v$PACKAGE_VERSION"
           git push --force --set-upstream origin "$branch"
 
-          pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""')
-          if [ -n "$pr_number" ]; then
-            echo "Updated existing PR #$pr_number"
-            exit 0
-          fi
+          pr_number=$(GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr list --repo microsoft/winget-pkgs --head "$fork_owner:$branch" --base master --state open --json number --jq 'first(.[].number) // ""' 2>/dev/null || true)
 
-          cat > /tmp/winget-pr-body.md <<EOF
-          Add WinGet manifests for $PACKAGE_IDENTIFIER $PACKAGE_VERSION.
-
-          - publishes the Windows portable ZIP for a2acli
-          - points WinGet at the a2a-rs GitHub release asset and checksum-backed digest
-          - generated from the a2a-rs CLI release automation
-
-          Upstream release: $RELEASE_URL
-          EOF
-
-          GH_TOKEN="$WINGET_PKGS_TOKEN" gh pr create \
-            --repo microsoft/winget-pkgs \
-            --base master \
-            --head "$fork_owner:$branch" \
-            --title "Add WinGet manifest for a2aproject.a2acli version $PACKAGE_VERSION" \
-            --body-file /tmp/winget-pr-body.md
+          {
+            echo "### WinGet manifests for $PACKAGE_IDENTIFIER $PACKAGE_VERSION"
+            echo
+            if [ -n "$pr_number" ]; then
+              echo "Pushed to \`$branch\`, which updates the open PR:"
+              echo
+              echo "https://github.com/microsoft/winget-pkgs/pull/$pr_number"
+            else
+              echo "Pushed to \`$branch\`. Open the upstream PR to publish it:"
+              echo
+              echo "https://github.com/microsoft/winget-pkgs/compare/master...$fork_owner:$branch?expand=1"
+              echo
+              echo "The GitHub App can push to the fork but cannot open the PR:"
+              echo "an App token only acts on repositories the App is installed on,"
+              echo "and microsoft/winget-pkgs is not one of them."
+            fi
+            echo
+            echo "Upstream release: $RELEASE_URL"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Supersedes #121.

`gh pr create` against microsoft/winget-pkgs fails with `Resource not accessible by
integration`: an App token only acts on repos the App is installed on. The job now
pushes the branch and writes the compare link to the run summary. Re-running
force-pushes the same branch, so an open PR updates in place.

Matches agntcy/shadi.