### PR TITLE
fix(server): clamp the page token offset when listing tasks

### DIFF
--- a/a2a-server/src/task_store/inmemory.rs
+++ b/a2a-server/src/task_store/inmemory.rs
@@ -96,7 +96,9 @@ impl TaskStore for InMemoryTaskStore {
         };
 
         let total_size = tasks.len();
-        let end = (start + page_size).min(total_size);
+        // Make sure start is within bounds
+        let start = start.min(total_size);
+        let end = start.saturating_add(page_size).min(total_size);
         let page = tasks[start..end].to_vec();
 
         let next_page_token = if end < total_size {
@@ -344,5 +346,35 @@ mod tests {
         };
         let resp = store.list(&req).await.unwrap();
         assert_eq!(resp.tasks[0].history.as_ref().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_out_of_range_page_token_returns_empty_page() {
+        let store = InMemoryTaskStore::new();
+        for i in 0..3 {
+            store
+                .create(make_task(&format!("t{i}"), "c1", TaskState::Submitted))
+                .await
+                .unwrap();
+        }
+
+        let req = ListTasksRequest {
+            context_id: None,
+            status: None,
+            page_size: None,
+            page_token: Some("999".to_string()),
+            history_length: None,
+            status_timestamp_after: None,
+            include_artifacts: None,
+            tenant: None,
+        };
+        let resp = store.list(&req).await.unwrap();
+
+        assert!(resp.tasks.is_empty());
+        assert!(
+            resp.next_page_token.is_empty(),
+            "must not hand back another token"
+        );
+        assert_eq!(resp.total_size, 3);
     }
 }


### PR DESCRIPTION
## What

`InMemoryTaskStore::list` panics when the page token points past the end
of the result set.

```
thread 'tokio-rt-worker' panicked at a2a-server/src/task_store/inmemory.rs:100:25:
range start index 1 out of range for slice of length 0
```

`page_token` was parsed into a start offset, but only `end` was clamped to
`total_size`. Once `start > end`, `tasks[start..end]` panics.

## Why this is not just malformed input

The page token is a raw offset into the result set *as it looked at that
moment*, and a `status` filter shrinks that set between calls. A client
that does nothing but echo back the server's own `nextPageToken` hits it:

1. `ListTasks(status=WORKING, pageSize=50)` over 60 working tasks
   → 50 tasks, `nextPageToken="50"`
2. the agent completes 40 of them (normal operation)
3. client asks for page 2 with `"50"` → the filtered list is now 20 long
   → panic

The panic aborts the connection, so the client sees an empty reply rather
than an HTTP or JSON-RPC error, which makes it awkward to diagnose from
the client side. The process itself survives.

## Repro on `main`

Against the bundled example server, with no tasks created at all:

```sh
cargo run --bin helloworld-server --package examples
curl -i 'http://127.0.0.1:3000/rest/tasks?pageToken=1'
# curl: (52) Empty reply from server
```

Same on the JSON-RPC binding:

```sh
curl -X POST http://127.0.0.1:3000/jsonrpc -H 'content-type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"ListTasks","params":{"pageToken":"1"}}'
```

## Fix

Clamp `start` to the result length, so a stale or out-of-range token
returns an empty final page with no `nextPageToken` and the client's
pagination loop terminates cleanly.

This matches how `DefaultRequestHandler::list_push_configs` already
paginates push configs — that path clamps with `.min(configs.len())`.
The task store was the odd one out.

## Behavior change

An out-of-range `pageToken` now returns an empty page instead of
panicking. Nothing that previously succeeded changes.

Returning `INVALID_ARGUMENT` was considered and rejected: the honest
client in the scenario above would then get a hard error mid-iteration,
and it would diverge from `list_push_configs`.

## Not covered here

Two adjacent issues in the same function, left out to keep this focused
on the panic — happy to file follow-ups:

- an unparseable `pageToken` is silently treated as page 1
  (`unwrap_or(0)`), so a client with a corrupted token re-reads page 1
  with no signal
- `page_size` is not capped at the 100 documented in `a2a.proto`

## Testing

- new `test_list_out_of_range_page_token_returns_empty_page`, which
  asserts the empty page **and** the empty `nextPageToken` (the latter is
  what keeps a client from looping)
- `just test` / `cargo test --workspace`
- `just fmt-check`, `just lint` clean
- verified the two curl repros above now return `200` with no panic in
  the server log

Fixes #139

PR descirption was generated by Claude Code. 